### PR TITLE
Add support for SSR, revamp error handling

### DIFF
--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -1,3 +1,28 @@
+<script setup lang="ts">
+const { loading: { onMountedWithLoading, clearLoading }, error: { errorModalVisible, error } } = useModal()
+
+const handleError = (err: Error) => {
+  error.value = err
+  errorModalVisible.value = true
+  clearLoading()
+}
+
+onErrorCaptured((err: unknown, _instance: ComponentPublicInstance | null, _info: string) => {
+  let error: Error | undefined
+  if (err instanceof Error) {
+    error = err
+  } else if (typeof (err) === 'string') {
+    error = new Error(err)
+  } else {
+    error = new Error('unknown error', { cause: err })
+  }
+  handleError(error)
+  return false // Don't propagate
+})
+
+onMountedWithLoading(() => { /* nothing to do */ }, 'defaultLayout.onMountedWithLoading')
+</script>
+
 <template>
   <NuxtLayout />
 </template>

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { loading: { onMountedWithLoading, clearLoading }, error: { errorModalVisible, error } } = useModal()
+const { loading: { clearLoading }, error: { errorModalVisible, error } } = useModal()
 
 const handleError = (err: Error) => {
   error.value = err
@@ -19,8 +19,6 @@ onErrorCaptured((err: unknown, _instance: ComponentPublicInstance | null, _info:
   handleError(error)
   return false // Don't propagate
 })
-
-onMountedWithLoading(() => { /* nothing to do */ }, 'defaultLayout.onMountedWithLoading')
 </script>
 
 <template>

--- a/frontend/components/modal/Error.vue
+++ b/frontend/components/modal/Error.vue
@@ -1,32 +1,27 @@
 <script setup lang="ts">
-import { watch } from 'vue'
-
 interface Props {
-  isFullPage?: boolean
+  routeBackOnClose?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  isFullPage: false
+  routeBackOnClose: false
 })
 
 const { error: { errorModalVisible, error: modalError } } = useModal()
 const error = useError()
 const router = useRouter()
 
-watch(errorModalVisible, async (newV, oldV) => {
-  if (!props.isFullPage) {
+const maybeGoBack = async () => {
+  if (!props.routeBackOnClose) {
     return
   }
-  // We only care about the case where the modal was just closed (i.e. has gone from visible -> not visible).
-  if (newV || !oldV) {
-    return
-  }
+
   if (window.history.length > 1) {
     await clearError().then(router.back)
   } else {
     await clearError({ redirect: '/' })
   }
-})
+}
 
 const fullError = computed(() => {
   const err = error.value ?? modalError.value
@@ -49,6 +44,7 @@ const fullError = computed(() => {
     v-model:visible="errorModalVisible"
     header="An error ocurred"
     sub-header="Sorry about that, our team take bug reports seriously, and will try to make it right!"
+    @closed="maybeGoBack"
   >
     <StandardDebug
       label="Error Details"

--- a/frontend/components/standard/Debug.vue
+++ b/frontend/components/standard/Debug.vue
@@ -10,25 +10,22 @@ const props = withDefaults(defineProps<Props>(), { always: false, label: 'Techni
 </script>
 
 <template>
-  <!-- TODO(#9) Remove this ClientOnly once the ULS is fixed. -->
-  <ClientOnly>
-    <PVAccordion
-      v-if="showStandardDebug || props.always"
-      class="standard-debug"
+  <PVAccordion
+    v-if="showStandardDebug || props.always"
+    class="standard-debug"
+  >
+    <PVAccordionTab
+      :header="props.label || 'Debug'"
+      content-class="surface-100"
+      header-class="surface-800"
     >
-      <PVAccordionTab
-        :header="props.label || 'Debug'"
-        content-class="surface-100"
-        header-class="surface-800"
+      <div
+        class="code surface-50"
       >
-        <div
-          class="code surface-50"
-        >
-          {{ JSON.stringify(props.value, null, 2) }}
-        </div>
-      </PVAccordionTab>
-    </PVAccordion>
-  </ClientOnly>
+        {{ JSON.stringify(props.value, null, 2) }}
+      </div>
+    </PVAccordionTab>
+  </PVAccordion>
 </template>
 
 <style lang="scss">

--- a/frontend/composables/newModal.ts
+++ b/frontend/composables/newModal.ts
@@ -35,7 +35,7 @@ export const useModal = () => {
     return () => loadingSet.value.delete(loadKey)
   }
   const clearLoading = () => { loadingSet.value.clear() }
-  const withLoadingAndErrorHandling = async <T> (fn: () => Promise<T>, opKey: string): (Promise<T>) => {
+  const withLoading = async <T> (fn: () => Promise<T>, opKey: string): (Promise<T>) => {
     startLoading(opKey)
     const p = fn()
     void p.finally(stopLoading(opKey))
@@ -77,7 +77,7 @@ export const useModal = () => {
     anyBlockingModalOpen,
     newModalVisibilityState,
     loading: {
-      withLoadingAndErrorHandling,
+      withLoading,
       onMountedWithLoading,
       startLoading,
       stopLoading,
@@ -88,7 +88,6 @@ export const useModal = () => {
     error: {
       error,
       errorModalVisible,
-      withLoadingAndErrorHandling,
       handleOAPIError
     },
     permissionDenied: {

--- a/frontend/composables/newModal.ts
+++ b/frontend/composables/newModal.ts
@@ -23,21 +23,7 @@ export const useModal = () => {
 
   // error
   const errorModalVisible = newModalVisibilityState('errorModalVisible')
-  const error = useState<Error | null>(`${prefix}.error`, () => null)
-  const setError = (opKey: string) => {
-    return (err?: Error) => {
-      error.value = err ?? new Error('an unknown error occurred')
-      errorModalVisible.value = true
-      clearLoading()
-
-      // We used to re-throw here, but that just breaks the page (e.g. no more
-      // navigation), since it ends up propagating to the top-level. Since
-      // setError is 'handling' the error, we don't re-throw.
-    }
-  }
-  const withErrorHandling = async (fn: () => Promise<unknown>, opKey: string): Promise<unknown> => {
-    return await fn().catch(setError(opKey))
-  }
+  const error = useState<Error>('errorModal.error')
 
   // loading
   const loadingSet = useState<Set<string>>(`${prefix}.loadingSet`, () => new Set<string>())
@@ -52,7 +38,7 @@ export const useModal = () => {
   const withLoadingAndErrorHandling = async <T> (fn: () => Promise<T>, opKey: string): (Promise<T>) => {
     startLoading(opKey)
     const p = fn()
-    p.catch(setError(opKey)).finally(stopLoading(opKey))
+    void p.finally(stopLoading(opKey))
     return await p
   }
   const onMountedWithLoading = (fn: () => void, opKey: string) => {
@@ -74,10 +60,13 @@ export const useModal = () => {
   const anyBlockingModalOpen = computed(() => anyModalVisible.value || loading.value)
 
   const handleOAPIError = async <T>(t: OPAIError | T): Promise<T> => {
-    return await new Promise<T>((resolve, reject) => {
+    return await new Promise<T>((resolve) => {
       // TODO(#10) Rephrase this once we use 300+ for all errors
       if (t instanceof Object && Object.prototype.hasOwnProperty.call(t, 'message')) {
-        reject(new Error(JSON.stringify(t)))
+        throw createError({
+          message: 'error from API',
+          cause: t
+        })
       } else {
         resolve(t as T)
       }
@@ -97,9 +86,7 @@ export const useModal = () => {
       loadingSet
     },
     error: {
-      setError,
       error,
-      withErrorHandling,
       errorModalVisible,
       withLoadingAndErrorHandling,
       handleOAPIError

--- a/frontend/composables/useAPI.ts
+++ b/frontend/composables/useAPI.ts
@@ -14,6 +14,9 @@ export const useAPI = (): API => {
     WITH_CREDENTIALS: true
   }
 
+  // If we're on the server, forward our cookie header along to the backend
+  // API for auth. We don't do this for the UserClient because it uses separate
+  // auth.
   let headers: Record<string, string> = {}
   if (process.server) {
     headers = Object.entries(useRequestHeaders(['cookie']))

--- a/frontend/composables/useAPI.ts
+++ b/frontend/composables/useAPI.ts
@@ -19,9 +19,7 @@ export const useAPI = (): API => {
   // auth.
   let headers: Record<string, string> = {}
   if (process.server) {
-    headers = Object.entries(useRequestHeaders(['cookie']))
-      .filter((ent) => !!ent[1])
-      .reduce((a, v) => ({ ...a, [v[0]]: v[1] }), {})
+    headers = useRequestHeaders(['cookie'])
   }
 
   const userCfg = {

--- a/frontend/composables/useAPI.ts
+++ b/frontend/composables/useAPI.ts
@@ -13,6 +13,14 @@ export const useAPI = (): API => {
     CREDENTIALS: 'include' as const, // To satisfy typing of 'include' | 'same-origin' | etc
     WITH_CREDENTIALS: true
   }
+
+  let headers: Record<string, string> = {}
+  if (process.server) {
+    headers = Object.entries(useRequestHeaders(['cookie']))
+      .filter((ent) => !!ent[1])
+      .reduce((a, v) => ({ ...a, [v[0]]: v[1] }), {})
+  }
+
   const userCfg = {
     ...baseCfg,
     BASE: authServerURL
@@ -21,7 +29,8 @@ export const useAPI = (): API => {
 
   const pactaClient = new PACTAClient({
     ...baseCfg,
-    BASE: apiServerURL
+    BASE: apiServerURL,
+    HEADERS: headers
   })
 
   return {

--- a/frontend/error.vue
+++ b/frontend/error.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+// We get the equivalent of props.error from useError() in the ModalError component.
+// const props = defineProps({
+//   error: Object
+// })
+
+const { error: { errorModalVisible } } = useModal()
+errorModalVisible.value = true
+</script>
+
+<template>
+  <ModalError :is-full-page="true" />
+</template>

--- a/frontend/error.vue
+++ b/frontend/error.vue
@@ -9,5 +9,5 @@ errorModalVisible.value = true
 </script>
 
 <template>
-  <ModalError :is-full-page="true" />
+  <ModalError :route-back-on-close="true" />
 </template>

--- a/frontend/globalimports/present.ts
+++ b/frontend/globalimports/present.ts
@@ -1,15 +1,23 @@
-import { ErrorWithRemediation, Remediation } from '@/lib/error'
+import { createErrorWithRemediation, Remediation } from '@/lib/error'
 
-export const present = <T>(t: T | undefined | null, r: Remediation): T => {
+export const present = <T>(t: T | undefined | null, r: Remediation, cause?: string): T => {
   if (t === undefined) {
-    throw new ErrorWithRemediation(`expected to be present but was undefined: ${typeof t}.`, r)
+    throw createErrorWithRemediation({
+      name: 'present error',
+      message: 'expected to be present but was undefined',
+      cause
+    }, r)
   }
   if (t === null) {
-    throw new ErrorWithRemediation(`expected to be present but was null: ${typeof t}.`, r)
+    throw createErrorWithRemediation({
+      name: 'present error',
+      message: 'expected to be present but was null',
+      cause
+    }, r)
   }
   return t
 }
 
-export const presentOrSuggestReload = <T>(t: T | undefined | null): T => present(t, Remediation.Reload)
-export const presentOrFileBug = <T>(t: T | undefined | null): T => present(t, Remediation.FileBug)
-export const presentOrCheckURL = <T>(t: T | undefined | null): T => present(t, Remediation.CheckUrl)
+export const presentOrSuggestReload = <T>(t: T | undefined | null, cause?: string): T => present(t, Remediation.Reload, cause)
+export const presentOrFileBug = <T>(t: T | undefined | null, cause?: string): T => present(t, Remediation.FileBug, cause)
+export const presentOrCheckURL = <T>(t: T | undefined | null, cause?: string): T => present(t, Remediation.CheckUrl, cause)

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+const { loading: { onMountedWithLoading }, anyBlockingModalOpen } = useModal()
 
-const { anyBlockingModalOpen } = useModal()
+onMountedWithLoading(() => { /* nothing to do */ }, 'defaultLayout.onMountedWithLoading')
 </script>
 
 <template>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -1,20 +1,6 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
 
-const { loading: { onMountedWithLoading, loadingSet }, anyBlockingModalOpen, error: { setError } } = useModal()
-
-const handleError = (event: Event & { reason: Error }) => {
-  event.preventDefault()
-  const { reason } = event
-  setError('fallback')(reason)
-  loadingSet.value.clear()
-}
-
-onMountedWithLoading(() => { /* nothing to do */ }, 'defaultLayout.onMountedWithLoading')
-onMounted(() => {
-  window.addEventListener('unhandledrejection', handleError)
-})
-
+const { anyBlockingModalOpen } = useModal()
 </script>
 
 <template>
@@ -28,13 +14,7 @@ onMounted(() => {
         class="px-3 md:px-4 w-full lg:w-10 xl:w-8 mx-auto"
         style="min-height: calc(100vh - 9rem - 4px);"
       >
-        <NuxtErrorBoundary>
-          <template #error="{ error, clearError }">
-            {{ setError(error) }}
-            {{ clearError() }}
-          </template>
-          <NuxtPage />
-        </NuxtErrorBoundary>
+        <NuxtPage />
       </main>
     </div>
     <ModalGroup />

--- a/frontend/lib/error/index.ts
+++ b/frontend/lib/error/index.ts
@@ -1,3 +1,5 @@
+import { type NuxtError } from 'nuxt/app'
+
 export enum Remediation {
   None = 'none',
   Reload = 'reload',
@@ -5,8 +7,26 @@ export enum Remediation {
   CheckUrl = 'check-url',
 }
 
-export class ErrorWithRemediation extends Error {
-  constructor (msg: string, public readonly remediation: Remediation) {
-    super(msg)
+interface RemediationData {
+  type: 'remediation'
+  remediation: Remediation
+}
+
+type PACTAErrorData = RemediationData
+
+interface PACTAError extends NuxtError {
+  data: PACTAErrorData
+}
+
+export const createErrorWithRemediation = (err: string | Partial<NuxtError>, r: Remediation): PACTAError => {
+  const nuxtErr = createError(err)
+  if (!nuxtErr.data || typeof (nuxtErr.data) !== 'object') {
+    nuxtErr.data = {}
   }
+  nuxtErr.data.type = 'remediation'
+  nuxtErr.data.remediation = r
+
+  // TypeScript doesn't automatically pick up that `data` is always set, so we
+  // give it a nudge.
+  return nuxtErr as PACTAError
 }

--- a/frontend/pages/admin/index.vue
+++ b/frontend/pages/admin/index.vue
@@ -55,5 +55,5 @@ const adminItems: AdminItem[] = [
         </PVCard>
       </div>
     </div>
-  </standardcontent>
+  </StandardContent>
 </template>

--- a/frontend/pages/admin/pacta-version/[id].vue
+++ b/frontend/pages/admin/pacta-version/[id].vue
@@ -20,7 +20,7 @@ if (error.value) {
   throw createError(error.value)
 }
 if (!persistedPactaVersion.value) {
-  throw new Error('PACTA version not found')
+  throw createError({ message: 'PACTA version not found' })
 }
 pactaVersion.value = { ...persistedPactaVersion.value }
 const refreshPACTA = async () => {

--- a/frontend/pages/admin/pacta-version/index.vue
+++ b/frontend/pages/admin/pacta-version/index.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts">
 const router = useRouter()
 const { pactaClient } = useAPI()
-const { error: { withLoadingAndErrorHandling, handleOAPIError } } = useModal()
+const { loading: { withLoading }, error: { handleOAPIError } } = useModal()
 
 const prefix = 'admin/pacta-version'
 const { data: pactaVersions, refresh } = await useAsyncData(`${prefix}.getPactaVersions`, () => {
-  return withLoadingAndErrorHandling(() => {
+  return withLoading(() => {
     return pactaClient.listPactaVersions().then(handleOAPIError)
   }, `${prefix}.getPactaVersions`)
 })
 
 const newPV = () => router.push('/admin/pacta-version/new')
-const markDefault = (id: string) => withLoadingAndErrorHandling(
+const markDefault = (id: string) => withLoading(
   () => pactaClient.markPactaVersionAsDefault(id)
     .then(handleOAPIError)
     .then(refresh),
   `${prefix}.markPactaVersionAsDefault`
 )
-const deletePV = (id: string) => withLoadingAndErrorHandling(
+const deletePV = (id: string) => withLoading(
   () => pactaClient.deletePactaVersion(id)
     .then(handleOAPIError)
     .then(refresh),

--- a/frontend/pages/admin/pacta-version/new.vue
+++ b/frontend/pages/admin/pacta-version/new.vue
@@ -3,7 +3,7 @@ import { type PactaVersion } from '@/openapi/generated/pacta'
 
 const router = useRouter()
 const { pactaClient } = useAPI()
-const { error: { withLoadingAndErrorHandling, handleOAPIError } } = useModal()
+const { loading: { withLoading }, error: { handleOAPIError } } = useModal()
 
 const prefix = 'admin/pacta-version/new'
 const pactaVersion = useState<PactaVersion>(`${prefix}.pactaVersion`, () => ({
@@ -16,7 +16,7 @@ const pactaVersion = useState<PactaVersion>(`${prefix}.pactaVersion`, () => ({
 }))
 
 const discard = () => router.push('/admin/pacta-version')
-const save = () => withLoadingAndErrorHandling(
+const save = () => withLoading(
   () => pactaClient.createPactaVersion(pactaVersion.value).then(handleOAPIError).then(() => router.push('/admin/pacta-version')),
   `${prefix}.save`
 )


### PR DESCRIPTION
This PR gets the SSR ball rolling, such that API requests can now be served via SSR. This is basically just sprinkling `useAsyncData` around and forwarding client cookies during SSR in `useAPI`.

This PR also has a kinda related refactoring of error handling stuff.

## Error Handling Refactor

Now, all error management is done by just `throw`-ing things.

* API returns a non-2xx code? **Throw it** (Axios/the codegen does this for us)
* API response contains an error? **Throw it** (currently in `handleOAPIError`, will go away with #10)
* Error from your `useAsyncData`? **Throw it**
* Data you require is unexpectedly null? **Throw it**

We use [`createError`](https://nuxt.com/docs/getting-started/error-handling#createerror) for everything now, as it gives us a standardized interface to put metadata in, which we can then use to show more useful error messages.

As part of the refactoring, I replaced `NuxtErrorBoundary` with Vue's `onErrorCaptured`, because the former was causing me some problems ([maybe the same problems as others](https://github.com/nuxt/nuxt/issues/15781)). I also moved things from `layouts/default.vue` into `app.vue`, because I feel like error handling is something we'll want everywhere. We can migrate bits back to `layouts/default.vue` as desired.

There's also a new `error.vue` which just wraps our error modal for those times where Nuxt throws a full page error (e.g. a failure during SSR).

Fixes #13