### PR TITLE
Use HTTP 204 No Content for endpoints without response bodies

### DIFF
--- a/cmd/server/pactasrv/initiative.go
+++ b/cmd/server/pactasrv/initiative.go
@@ -23,7 +23,7 @@ func (s *Server) CreateInitiative(ctx context.Context, request api.CreateInitiat
 	if err != nil {
 		return nil, oapierr.Internal("failed to create initiative", zap.Error(err))
 	}
-	return api.CreateInitiative200Response{}, nil
+	return api.CreateInitiative204Response{}, nil
 }
 
 // Updates an initiative
@@ -68,7 +68,7 @@ func (s *Server) UpdateInitiative(ctx context.Context, request api.UpdateInitiat
 	if err != nil {
 		return nil, oapierr.Internal("failed to update initiative", zap.String("initiative_id", string(id)), zap.Error(err))
 	}
-	return api.UpdateInitiative200Response{}, nil
+	return api.UpdateInitiative204Response{}, nil
 }
 
 // Deletes an initiative by id
@@ -79,7 +79,7 @@ func (s *Server) DeleteInitiative(ctx context.Context, request api.DeleteInitiat
 	if err != nil {
 		return nil, oapierr.Internal("failed to delete initiative", zap.Error(err))
 	}
-	return api.DeleteInitiative200Response{}, nil
+	return api.DeleteInitiative204Response{}, nil
 }
 
 // Returns an initiative by ID

--- a/cmd/server/pactasrv/pacta_version.go
+++ b/cmd/server/pactasrv/pacta_version.go
@@ -55,7 +55,7 @@ func (s *Server) CreatePactaVersion(ctx context.Context, request api.CreatePacta
 	if _, err := s.DB.CreatePACTAVersion(s.DB.NoTxn(ctx), pv); err != nil {
 		return nil, oapierr.Internal("failed to create pacta version", zap.Error(err))
 	}
-	return api.CreatePactaVersion200Response{}, nil
+	return api.CreatePactaVersion204Response{}, nil
 }
 
 // Updates a PACTA version
@@ -78,7 +78,7 @@ func (s *Server) UpdatePactaVersion(ctx context.Context, request api.UpdatePacta
 	if err != nil {
 		return nil, oapierr.Internal("failed to update pacta version", zap.String("pacta_version_id", string(id)), zap.Error(err))
 	}
-	return api.UpdatePactaVersion200Response{}, nil
+	return api.UpdatePactaVersion204Response{}, nil
 
 }
 
@@ -91,7 +91,7 @@ func (s *Server) DeletePactaVersion(ctx context.Context, request api.DeletePacta
 	if err != nil {
 		return nil, oapierr.Internal("failed to delete pacta version", zap.String("pacta_version_id", string(id)), zap.Error(err))
 	}
-	return api.DeletePactaVersion200Response{}, nil
+	return api.DeletePactaVersion204Response{}, nil
 }
 
 // Marks this version of the PACTA model as the default
@@ -103,5 +103,5 @@ func (s *Server) MarkPactaVersionAsDefault(ctx context.Context, request api.Mark
 	if err != nil {
 		return nil, oapierr.Internal("failed to set default pacta version", zap.String("pacta_version_id", string(id)), zap.Error(err))
 	}
-	return api.MarkPactaVersionAsDefault200Response{}, nil
+	return api.MarkPactaVersionAsDefault204Response{}, nil
 }

--- a/frontend/openapi/generated/pacta/services/DefaultService.ts
+++ b/frontend/openapi/generated/pacta/services/DefaultService.ts
@@ -41,13 +41,13 @@ export class DefaultService {
      * Updates a PACTA version's settable properties
      * @param id ID of PACTA version to update
      * @param requestBody PACTA Version object properties to update
-     * @returns any pacta version updated successfully
+     * @returns void
      * @throws ApiError
      */
     public updatePactaVersion(
         id: string,
         requestBody: PactaVersionChanges,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'PATCH',
             url: '/pacta-version/{id}',
@@ -63,12 +63,12 @@ export class DefaultService {
      * Deletes a pacta version by ID
      * deletes a single pacta version based on the ID supplied
      * @param id ID of pacta version to delete
-     * @returns any pacta version deleted successfully
+     * @returns void
      * @throws ApiError
      */
     public deletePactaVersion(
         id: string,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'DELETE',
             url: '/pacta-version/{id}',
@@ -81,12 +81,12 @@ export class DefaultService {
     /**
      * Marks this version of the PACTA model as the default
      * @param id ID of pacta version to fetch
-     * @returns any updated successfully
+     * @returns void
      * @throws ApiError
      */
     public markPactaVersionAsDefault(
         id: string,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'POST',
             url: '/pacta-version/{id}/set-default',
@@ -112,12 +112,12 @@ export class DefaultService {
      * Creates a PACTA version
      * Creates a PACTA version
      * @param requestBody PACTA Version object properties to update
-     * @returns any pacta version created successfully
+     * @returns void
      * @throws ApiError
      */
     public createPactaVersion(
         requestBody: PactaVersionCreate,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'POST',
             url: '/pacta-versions',
@@ -149,13 +149,13 @@ export class DefaultService {
      * Updates an initiative's settable properties
      * @param id ID of the initiative to update
      * @param body initiative object properties to update
-     * @returns any initiative updated successfully
+     * @returns void
      * @throws ApiError
      */
     public updateInitiative(
         id: string,
         body: InitiativeChanges,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'PATCH',
             url: '/initiative/{id}',
@@ -172,12 +172,12 @@ export class DefaultService {
      * Deletes an initiative by id
      * deletes an initiative based on the ID supplied
      * @param id ID of initiative to delete
-     * @returns any initiative deleted successfully
+     * @returns void
      * @throws ApiError
      */
     public deleteInitiative(
         id: string,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'DELETE',
             url: '/initiative/{id}',
@@ -203,12 +203,12 @@ export class DefaultService {
      * Creates a initiative
      * Creates a new initiative
      * @param requestBody Initiative object properties to update
-     * @returns any initiative created successfully
+     * @returns void
      * @throws ApiError
      */
     public createInitiative(
         requestBody: InitiativeCreate,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'POST',
             url: '/initiatives',
@@ -254,13 +254,13 @@ export class DefaultService {
      * Updates a user's settable properties
      * @param id ID of user to update
      * @param requestBody User object properties to update
-     * @returns any the new user object
+     * @returns void
      * @throws ApiError
      */
     public updateUser(
         id: string,
         requestBody: UserChanges,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'PATCH',
             url: '/user/{id}',
@@ -276,12 +276,12 @@ export class DefaultService {
      * Deletes a user by ID
      * deletes a single user based on the ID supplied
      * @param id ID of user to delete
-     * @returns any user deleted
+     * @returns void
      * @throws ApiError
      */
     public deleteUser(
         id: string,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'DELETE',
             url: '/user/{id}',

--- a/frontend/pages/admin/pacta-version/index.vue
+++ b/frontend/pages/admin/pacta-version/index.vue
@@ -13,12 +13,12 @@ const { data: pactaVersions, refresh } = await useAsyncData(`${prefix}.getPactaV
 const newPV = () => router.push('/admin/pacta-version/new')
 const markDefault = (id: string) => withLoading(
   () => pactaClient.markPactaVersionAsDefault(id)
-    .then(refresh),
+    .then(() => refresh()),
   `${prefix}.markPactaVersionAsDefault`
 )
 const deletePV = (id: string) => withLoading(
   () => pactaClient.deletePactaVersion(id)
-    .then(refresh),
+    .then(() => refresh()),
   `${prefix}.deletePactaVersion`
 )
 </script>

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -65,7 +65,7 @@ paths:
             schema:
               $ref: '#/components/schemas/PactaVersionChanges'
       responses:
-        '200':
+        '204':
           description: pacta version updated successfully 
     delete:
       summary: Deletes a pacta version by ID
@@ -79,7 +79,7 @@ paths:
           schema:
             type: string 
       responses:
-        '200':
+        '204':
           description: pacta version deleted successfully 
   
   /pacta-version/{id}/set-default:
@@ -94,7 +94,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        '204':
           description: updated successfully 
     
   /pacta-versions:
@@ -122,7 +122,7 @@ paths:
             schema:
               $ref: '#/components/schemas/PactaVersionCreate'
       responses:
-        '200':
+        '204':
           description: pacta version created successfully 
 
   /initiative/{id}:
@@ -161,7 +161,7 @@ paths:
           schema:
             $ref: '#/components/schemas/InitiativeChanges'
       responses:
-        '200':
+        '204':
           description: initiative updated successfully 
     
     delete:
@@ -176,7 +176,7 @@ paths:
           schema:
             type: string 
       responses:
-        '200':
+        '204':
           description: initiative deleted successfully 
 
   /initiatives:
@@ -204,7 +204,7 @@ paths:
             schema:
               $ref: '#/components/schemas/InitiativeCreate'
       responses:
-        '200':
+        '204':
           description: initiative created successfully 
 
   /user/me:
@@ -258,7 +258,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserChanges'
       responses:
-        '200':
+        '204':
           description: the new user object
     
     delete:
@@ -273,7 +273,7 @@ paths:
           schema:
             type: string 
       responses:
-        '200':
+        '204':
           description: user deleted
               
 components:


### PR DESCRIPTION
This is more semantically accurate and generates the expected `void` response in the frontend client code, see https://github.com/ferdikoomen/openapi-typescript-codegen/issues/607