### PR TITLE
Overhaul auth management

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "browser": true,
-    "es2021": true
+    "es2021": true,
+    "node": true
   },
   "ignorePatterns": [
     "openapi/generated/**/*.ts"
@@ -34,6 +35,7 @@
         "commentPattern": "fallthrough"
       }
     ],
+    "no-useless-return": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/strict-boolean-expressions": 0,
     "@typescript-eslint/promise-function-async": 0,

--- a/frontend/composables/useAPI.ts
+++ b/frontend/composables/useAPI.ts
@@ -1,45 +1,46 @@
-import { UserClient, type DefaultService as UserDefaultService } from '@/openapi/generated/user'
-import { PACTAClient, type DefaultService as PACTADefaultService } from '@/openapi/generated/pacta'
+import { UserClient } from '@/openapi/generated/user'
+import { PACTAClient } from '@/openapi/generated/pacta'
 
-interface API {
-  userClient: UserDefaultService
-  pactaClient: PACTADefaultService
-  userClientWithCustomToken: (tkn: string) => UserDefaultService
-}
+import type { BaseHttpRequest } from '@/openapi/generated/pacta/core/BaseHttpRequest'
+import type { OpenAPIConfig } from '@/openapi/generated/pacta/core/OpenAPI'
 
-export const useAPI = (): API => {
+type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest
+
+// Note: This is a low-level composable intended to be used by other
+// composables, like usePACTA or useMSAL, it probably shouldn't be used by end
+// clients.
+export const useAPI = () => {
   const { public: { apiServerURL, authServerURL } } = useRuntimeConfig()
+
   const baseCfg = {
     CREDENTIALS: 'include' as const, // To satisfy typing of 'include' | 'same-origin' | etc
     WITH_CREDENTIALS: true,
   }
 
-  // If we're on the server, forward our cookie header along to the backend
-  // API for auth. We don't do this for the UserClient because it uses separate
-  // auth.
-  let headers: Record<string, string> = {}
-  if (process.server) {
-    headers = useRequestHeaders(['cookie'])
-  }
-
-  const userCfg = {
-    ...baseCfg,
-    BASE: authServerURL,
-  }
-  const userClient = new UserClient(userCfg)
-
-  const pactaClient = new PACTAClient({
+  const pactaCfg = {
     ...baseCfg,
     BASE: apiServerURL,
-    HEADERS: headers,
-  })
+  }
 
   return {
-    userClient: userClient.default,
-    pactaClient: pactaClient.default,
-    userClientWithCustomToken: (tkn: string) => {
+    // The three different PACTA clients are for authentication in different
+    // cases (client/server, cookies/no cookies, etc).
+    pactaClient: new PACTAClient(pactaCfg).default,
+    pactaClientWithHttpRequestClass: (req: HttpRequestConstructor) => {
+      return new PACTAClient(pactaCfg, req).default
+    },
+    pactaClientWithAuth: (tkn: string) => {
+      return new PACTAClient({
+        ...pactaCfg,
+        TOKEN: tkn,
+      }).default
+    },
+    // Auth for the user service comes from Azure and needs to be manually
+    // appended to each UserService request.
+    userClientWithAuth: (tkn: string) => {
       const newCfg = {
-        ...userCfg,
+        ...baseCfg,
+        BASE: authServerURL,
         TOKEN: tkn,
       }
       return new UserClient(newCfg).default

--- a/frontend/composables/usePACTA.ts
+++ b/frontend/composables/usePACTA.ts
@@ -1,0 +1,63 @@
+import { type AuthenticationResult } from '@azure/msal-common'
+import type { ApiRequestOptions } from '~/openapi/generated/pacta/core/ApiRequestOptions'
+import { BaseHttpRequest } from '~/openapi/generated/pacta/core/BaseHttpRequest'
+import { CancelablePromise } from '~/openapi/generated/pacta/core/CancelablePromise'
+import type { OpenAPIConfig } from '~/openapi/generated/pacta/core/OpenAPI'
+import { request as __request } from '~/openapi/generated/pacta/core/request'
+
+export const usePACTA = async () => {
+  const {
+    pactaClient, // On the server, if there's no JWT
+    pactaClientWithAuth, // On the server, forward the cookie we got from the client
+    pactaClientWithHttpRequestClass, // On the client, wrap with a check for a fresh cookie.
+  } = useAPI()
+
+  if (process.server) {
+    const jwt = useCookie('jwt')
+    if (jwt.value) {
+      return pactaClientWithAuth(jwt.value)
+    }
+    return pactaClient
+  }
+
+  // If we're on the client, we can see if Azure has cached credentials and use
+  // those, or refresh them if not. Our cookies have the same lifetime as our
+  // access tokens, so we refresh them together.
+  const { getToken } = await useMSAL()
+
+  // We define this class as a variable so we can override the PACTA client
+  // with middleware that refreshes our credentials. This matches the
+  // interface of our auto-generated code, which expects a class that extends
+  // BaseHttpRequest.
+  const httpReqClass = class extends BaseHttpRequest {
+    private readonly getToken: () => Promise<AuthenticationResult>
+
+    constructor (config: OpenAPIConfig) {
+      super(config)
+      this.getToken = getToken
+    }
+
+    /**
+     * Request method
+     * @param options The request options from the service
+     * @returns CancelablePromise<T>
+     * @throws ApiError
+     */
+    public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+      return new CancelablePromise((resolve, reject, onCancel) => {
+        this.getToken()
+          .then(() => {
+            const cancelablePromise = __request<T>(this.config, options)
+            onCancel(() => {
+              cancelablePromise.cancel()
+            })
+            return cancelablePromise
+          })
+          .then(resolve)
+          .catch(reject)
+      })
+    }
+  }
+
+  return pactaClientWithHttpRequestClass(httpReqClass)
+}

--- a/frontend/envs/env.dev
+++ b/frontend/envs/env.dev
@@ -8,3 +8,4 @@ MSAL_CLIENT_ID=218f47ee-11b1-459a-b914-b7fa6f107e7b
 # See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md#redirecturi-considerations
 MSAL_REDIRECT_URI=https://pacta.dev.rmi.siliconally.dev/blank
 MSAL_LOGOUT_URI=https://pacta.dev.rmi.siliconally.dev/
+MSAL_MIN_LOG_LEVEL=INFO

--- a/frontend/envs/env.local
+++ b/frontend/envs/env.local
@@ -8,3 +8,4 @@ MSAL_CLIENT_ID=2d77a4a9-b7be-4451-ad47-c151d8b6c05f
 # See https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/initialization.md#redirecturi-considerations
 MSAL_REDIRECT_URI=http://localhost:3000/blank
 MSAL_LOGOUT_URI=http://localhost:3000/
+MSAL_MIN_LOG_LEVEL=INFO

--- a/frontend/middleware/admin.ts
+++ b/frontend/middleware/admin.ts
@@ -1,6 +1,6 @@
 export default defineNuxtRouteMiddleware(async () => {
   /* TODO(grady) add Authorization here
-  const { getMe } = useMSAL()
+  const { getMe } = await useMSAL()
   const { isAdmin } = await getMe()
   if (!isAdmin.value) {
     return await navigateTo('/denied')

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -25,6 +25,7 @@ export default defineNuxtConfig({
         clientID: process.env.MSAL_CLIENT_ID ?? '',
         redirectURI: process.env.MSAL_REDIRECT_URI ?? '',
         logoutURI: process.env.MSAL_LOGOUT_URI ?? '',
+        minLogLevel: process.env.MSAL_MIN_LOG_LEVEL ?? 'VERBOSE',
       },
     },
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "nuxt-app",
       "dependencies": {
-        "@azure/msal-browser": "^3.0.2",
+        "@azure/msal-browser": "^3.2.0",
         "primeflex": "^3.3.1",
         "primeicons": "^6.0.1",
         "primevue": "^3.32.0",
@@ -345,20 +345,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.0.2.tgz",
-      "integrity": "sha512-a2lIzWGV8EJhxVTHu2Vd5sRdK6DTisueq2HCXt49CQqc1hG/j9pK+ds+hJi+QLlZHPo3FPMwiTCHEA9sNgX3HA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.2.0.tgz",
+      "integrity": "sha512-le2qutddMiq0i3ErQaLKuwP1DpNgdd9iXPs3fSCsLuBrdGg9B4/j4ArCAHCwgxA82Ydj9BcqtMIL5BSWwU+P5A==",
       "dependencies": {
-        "@azure/msal-common": "14.0.2"
+        "@azure/msal-common": "14.1.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.0.2.tgz",
-      "integrity": "sha512-yvVP63oXe20JFzvooTVxiX9UorxcL8VFoVwEtKuGlQnEnNGzrOpQZ6lKa1lqwGqxMtwKpW7oAFQhbbskG5RbYA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.1.0.tgz",
+      "integrity": "sha512-xphmhcfl5VL+uq5//VKMwQn+wfEZLMKNpFCcMi8Ur8ej5UT166g6chBsxgMzc9xo9Y24R9FB3m/tjDiV03xMIA==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -13317,9 +13317,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -18812,17 +18812,17 @@
       }
     },
     "@azure/msal-browser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.0.2.tgz",
-      "integrity": "sha512-a2lIzWGV8EJhxVTHu2Vd5sRdK6DTisueq2HCXt49CQqc1hG/j9pK+ds+hJi+QLlZHPo3FPMwiTCHEA9sNgX3HA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.2.0.tgz",
+      "integrity": "sha512-le2qutddMiq0i3ErQaLKuwP1DpNgdd9iXPs3fSCsLuBrdGg9B4/j4ArCAHCwgxA82Ydj9BcqtMIL5BSWwU+P5A==",
       "requires": {
-        "@azure/msal-common": "14.0.2"
+        "@azure/msal-common": "14.1.0"
       }
     },
     "@azure/msal-common": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.0.2.tgz",
-      "integrity": "sha512-yvVP63oXe20JFzvooTVxiX9UorxcL8VFoVwEtKuGlQnEnNGzrOpQZ6lKa1lqwGqxMtwKpW7oAFQhbbskG5RbYA=="
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.1.0.tgz",
+      "integrity": "sha512-xphmhcfl5VL+uq5//VKMwQn+wfEZLMKNpFCcMi8Ur8ej5UT166g6chBsxgMzc9xo9Y24R9FB3m/tjDiV03xMIA=="
     },
     "@azure/msal-node": {
       "version": "1.18.3",
@@ -28244,9 +28244,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "vue-tsc": "^1.8.8"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.0.2",
+    "@azure/msal-browser": "^3.2.0",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",
     "primevue": "^3.32.0",

--- a/frontend/pages/admin/pacta-version/[id].vue
+++ b/frontend/pages/admin/pacta-version/[id].vue
@@ -2,7 +2,7 @@
 import { type PactaVersion, type PactaVersionChanges } from '@/openapi/generated/pacta'
 
 const router = useRouter()
-const { pactaClient } = useAPI()
+const pactaClient = await usePACTA()
 const { loading: { withLoading } } = useModal()
 const { fromParams } = useURLParams()
 

--- a/frontend/pages/admin/pacta-version/index.vue
+++ b/frontend/pages/admin/pacta-version/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const router = useRouter()
-const { pactaClient } = useAPI()
+const pactaClient = await usePACTA()
 const { loading: { withLoading } } = useModal()
 
 const prefix = 'admin/pacta-version'

--- a/frontend/pages/admin/pacta-version/new.vue
+++ b/frontend/pages/admin/pacta-version/new.vue
@@ -2,7 +2,7 @@
 import { type PactaVersion } from '@/openapi/generated/pacta'
 
 const router = useRouter()
-const { pactaClient } = useAPI()
+const pactaClient = await usePACTA()
 const { loading: { withLoading } } = useModal()
 
 const prefix = 'admin/pacta-version/new'


### PR DESCRIPTION
Update MSAL integration, mirrors changes we did to OPGEE with some PACTA-specific differences. More specifically:

- **Stay logged in between requests** - Before, if you refreshed the page, you were logged out. Very annoying. This is no longer the case.
- **Cache Azure credentials** - Since the credsrv token + and the Azure ID token expire at the same time, we can use the 'cached' status of the Azure token to decide if we need to refresh our own auth
- **Update MSAL to the latest version**
