### PR TITLE
Finish adding Event Grid validation, and add local testing tools

### DIFF
--- a/cmd/server/configs/dev.conf
+++ b/cmd/server/configs/dev.conf
@@ -1,3 +1,6 @@
 env dev
 allowed_cors_origin https://pacta.dev.rmi.siliconally.dev
 port 80
+
+azure_event_subscription 69b6db12-37e3-4e1f-b48c-aa41dba612a9
+azure_event_resource_group rmi-pacta-dev

--- a/cmd/server/configs/local.conf
+++ b/cmd/server/configs/local.conf
@@ -1,6 +1,9 @@
 env local
 allowed_cors_origin http://localhost:3000
 
+azure_event_subscription 69b6db12-37e3-4e1f-b48c-aa41dba612a9
+azure_event_resource_group rmi-pacta-local
+
 secret_postgres_host UNUSED
 # Also unused
 secret_postgres_port 1234

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/RMI/pacta/task"
 	"github.com/Silicon-Ally/cryptorand"
 	"github.com/Silicon-Ally/zaphttplog"
-	"github.com/go-chi/chi/v5"
+	chi "github.com/go-chi/chi/v5"
 	"github.com/go-chi/httprate"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -61,6 +61,9 @@ func run(args []string) error {
 
 		env      = fs.String("env", "", "The environment that we're running in.")
 		localDSN = fs.String("local_dsn", "", "If set, override the DB addresses retrieved from the secret configuration. Can only be used when running locally.")
+
+		azEventSubscription  = fs.String("azure_event_subscription", "", "The Azure Subscription ID to allow webhook registrations from")
+		azEventResourceGroup = fs.String("azure_event_resource_group", "", "The Azure resource group to allow webhook registrations from")
 
 		// Only when running locally because the Dockerized runner can't use local `az` CLI credentials
 		localDockerTenantID     = fs.String("local_docker_tenant_id", "", "The Azure Tenant ID the localdocker service principal lives in")
@@ -276,7 +279,9 @@ func run(args []string) error {
 	})
 
 	eventSrv, err := azevents.NewServer(&azevents.Config{
-		Logger: logger,
+		Logger:        logger,
+		Subscription:  *azEventSubscription,
+		ResourceGroup: *azEventResourceGroup,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to init Azure Event Grid handler: %w", err)

--- a/secrets/local.enc.json
+++ b/secrets/local.enc.json
@@ -4,6 +4,11 @@
 		"client_id": "ENC[AES256_GCM,data:yex2my4EAYV3k4czIZXn4gnANaS/jmpDV8gFVKOgeII5ce+h,iv:6/YnhiTdR1sVeR2QhNPmI/q1jb3oSQDODTqxAbDlESo=,tag:7SNZU0pbTt5QweGzKh3XoA==,type:str]",
 		"password": "ENC[AES256_GCM,data:rA7aewwH4umPWAnzuOen8oYgLwvQsf19rfGOWARbGfW5lXSuxx4F4g==,iv:KRq/lxZ28JfUkGeBlDvmMfpVLVbPlEmOD8l/aRfG5Zo=,tag:pH0oAueSsrXaXcuXM4LlEQ==,type:str]"
 	},
+	"frpc": {
+		"addr": "ENC[AES256_GCM,data:mke8TeqY6AWnbiWRQa6D0w==,iv:O8tnERYeDK2ACeOzlEiHnhty9ILYoi8cCSa80ngDHg4=,tag:zA/zMc0DIATseyF5BUVymQ==,type:str]",
+		"port": "ENC[AES256_GCM,data:d1sh9w==,iv:bmzN6duVQylgRXAchkPavtUsdbNdd+S3f7N73ukFV2A=,tag:4nFCulM5yYdMvTY2CwiJ0g==,type:float]",
+		"token": "ENC[AES256_GCM,data:qe9Hy0tKKrQ7rFzOQuTlDKGDqA2489hvEbjbtYFMuJ3wd5gy,iv:gV+OasDEHtI28TVBFmyxrPjMqEv5J1jpWMAzR1N70MQ=,tag:543oFV21kJj9qBgkyewdIg==,type:str]"
+	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -18,8 +23,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-10-28T02:50:38Z",
-		"mac": "ENC[AES256_GCM,data:16VSdcgdGXVxl6xeCv/2LmwOnHyJE8Y9sOEmY2y/c/CpAgNVLF+yBtQnBSQyMlVUskuBEFQxpcm1TQXjz11ngtlRIaITqJGcPDQoIdQMUvamP8Ku69pxrc0UPZOR5qv5BkAoZapCxH5xWWQPakgaHf74NES4Bn2FUe8tR6T50JM=,iv:gSTP1rTGhui1yuCsREeNR9JFcXfVyGfLcTTInAu27qs=,tag:0rv8y1y4qvTkL6DtH50KEw==,type:str]",
+		"lastmodified": "2023-10-31T18:08:10Z",
+		"mac": "ENC[AES256_GCM,data:OtzdhIFbPxagE61i0gA871aw8Pkl/PZrwigtX2S3tisOviuYwK0h1QNZN+eKTDXyEbs7fht4ruo4m6EEmZS2nwvgquAUaoA9A9yXARfYFRPQ3D5a21WH8nlN0JMBGoD70VwGjw22Yy2XfG5FbaOnVN2eQ5QpSHaDw1umEiR0rWE=,iv:YZIof2lisX96LDntHnsyDKzQjtlel5SM+Tvpq4C9Sn0=,tag:gEGFEGNB1Fvf1VMKLokMYg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"


### PR DESCRIPTION
This PR finishes up the work of validating requests from Event Grid, and adds support for running the server with a public-facing endpoint via the `--with_public_endpoint=<subdomain>` flag, which is proxied via [frp](https://github.com/fatedier/frp).

I didn't use our [frpembed](https://github.com/Silicon-Ally/frpembed) library because there's an issue with `quic-go` not supporting Go 1.20 (may be fixed, didn't want to go down the rabbithole)
