### PR TITLE
Address some feedback from #45

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -139,13 +139,13 @@ func run(args []string) error {
 		return fmt.Errorf("unknown task type %q", taskType)
 	}
 
-	logger.Info("running PACTA task", zap.String("task_type", string(taskType)))
+	logger.Info("running PACTA task", zap.String("task_id", string(taskID)), zap.String("task_type", string(taskType)))
 
 	if err := taskFn(ctx, taskID); err != nil {
 		return fmt.Errorf("error running task: %w", err)
 	}
 
-	logger.Info("ran PACTA task successfully", zap.String("task_type", string(taskType)))
+	logger.Info("ran PACTA task successfully", zap.String("task_id", string(taskID)), zap.String("task_type", string(taskType)))
 
 	return nil
 }


### PR DESCRIPTION
Specifically, add the `task_id` to log lines in the runner so we can figure out how long tasks are taking from the log output.
