### PR TITLE
Merge various RMI container registries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           allow-no-subscriptions: false
 
       - name: Login to ACR via OIDC
-        run: az acr login --name rmipacta
+        run: az acr login --name rmisa
 
       - uses: actions/setup-node@v3
         with:
@@ -65,7 +65,7 @@ jobs:
           containerAppName: pactasrv-dev
           containerAppEnvironment: pacta-dev
           resourceGroup: rmi-pacta-dev
-          imageToDeploy: rmipacta.azurecr.io/pacta:dev
+          imageToDeploy: rmisa.azurecr.io/pacta:dev
           location: centralus
 
       - name: Deploy frontend

--- a/cmd/runner/BUILD.bazel
+++ b/cmd/runner/BUILD.bazel
@@ -62,7 +62,7 @@ oci_push(
     name = "push_image",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "rmipacta.azurecr.io/runner",
+    repository = "rmisa.azurecr.io/runner",
 )
 
 # Note: This tarball is provided for local testing of the Docker image, see the README.md for details on usage.

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -139,13 +139,13 @@ func run(args []string) error {
 		return fmt.Errorf("unknown task type %q", taskType)
 	}
 
-	logger.Info("running PACTA task", zap.String("task_type", string(taskType)))
+	logger.Info("running PACTA task", zap.String("task_id", string(taskID)), zap.String("task_type", string(taskType)))
 
 	if err := taskFn(ctx, taskID); err != nil {
 		return fmt.Errorf("error running task: %w", err)
 	}
 
-	logger.Info("ran PACTA task successfully", zap.String("task_type", string(taskType)))
+	logger.Info("ran PACTA task successfully", zap.String("task_id", string(taskID)), zap.String("task_type", string(taskType)))
 
 	return nil
 }

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -74,7 +74,7 @@ oci_push(
     name = "push_image",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "rmipacta.azurecr.io/pacta",
+    repository = "rmisa.azurecr.io/pacta",
 )
 
 # Note: This tarball is provided for local testing of the Docker image, see the README.md for details on usage.

--- a/cmd/server/configs/local.conf
+++ b/cmd/server/configs/local.conf
@@ -26,5 +26,5 @@ secret_runner_config_identity_subscription_id 69b6db12-37e3-4e1f-b48c-aa41dba612
 secret_runner_config_identity_resource_group rmi-pacta-local
 secret_runner_config_identity_client_id c02b7346-6ba6-438a-8136-1ccb608e5449
 secret_runner_config_identity_managed_environment pacta-local
-secret_runner_config_image_registry rmipacta.azurecr.io
+secret_runner_config_image_registry rmisa.azurecr.io
 secret_runner_config_image_name runner

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -99,7 +99,7 @@ func run(args []string) error {
 		runnerConfigIdentityClientID           = fs.String("secret_runner_config_identity_client_id", "", "Client ID of the identity to run runner jobs with")
 		runnerConfigIdentityManagedEnvironment = fs.String("secret_runner_config_identity_managed_environment", "", "Name of the Container Apps Environment where runner jobs should run")
 
-		runnerConfigImageRegistry = fs.String("secret_runner_config_image_registry", "", "Registry where PACTA runner images live, like 'rmipacta.azurecr.io'")
+		runnerConfigImageRegistry = fs.String("secret_runner_config_image_registry", "", "Registry where PACTA runner images live, like 'rmisa.azurecr.io'")
 		runnerConfigImageName     = fs.String("secret_runner_config_image_name", "", "Name of the Docker image of the PACTA runner, like 'runner'")
 	)
 	// Allows for passing in configuration via a -config path/to/env-file.conf

--- a/task/task.go
+++ b/task/task.go
@@ -43,7 +43,7 @@ type EnvVar struct {
 }
 
 type BaseImage struct {
-	// Like 'rmipacta.azurecr.io'
+	// Like 'rmisa.azurecr.io'
 	Registry string
 	// Like 'runner'
 	Name string


### PR DESCRIPTION
A simple cost saving measure, since each of our (currently) four RMI registries costs like $1/day. I noticed it when checking our Azure credit burn rate.
