### PR TITLE
Creates Structure for Upload Requests

### DIFF
--- a/cmd/server/pactasrv/BUILD.bazel
+++ b/cmd/server/pactasrv/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "pacta_version.go",
         "pactasrv.go",
         "portfolio.go",
+        "upload.go",
         "user.go",
     ],
     importpath = "github.com/RMI/pacta/cmd/server/pactasrv",

--- a/cmd/server/pactasrv/pactasrv.go
+++ b/cmd/server/pactasrv/pactasrv.go
@@ -67,6 +67,12 @@ type DB interface {
 	CreatePortfolioInitiativeMembership(tx db.Tx, pim *pacta.PortfolioInitiativeMembership) error
 	DeletePortfolioInitiativeMembership(tx db.Tx, pid pacta.PortfolioID, iid pacta.InitiativeID) error
 
+	IncompleteUpload(tx db.Tx, id pacta.IncompleteUploadID) (*pacta.IncompleteUpload, error)
+	IncompleteUploads(tx db.Tx, ids []pacta.IncompleteUploadID) (map[pacta.IncompleteUploadID]*pacta.IncompleteUpload, error)
+	CreateIncompleteUpload(tx db.Tx, i *pacta.IncompleteUpload) (pacta.IncompleteUploadID, error)
+	UpdateIncompleteUpload(tx db.Tx, id pacta.IncompleteUploadID, mutations ...db.UpdateIncompleteUploadFn) error
+	DeleteIncompleteUpload(tx db.Tx, id pacta.IncompleteUploadID) (pacta.BlobURI, error)
+
 	GetOrCreateUserByAuthn(tx db.Tx, mech pacta.AuthnMechanism, authnID, email, canonicalEmail string) (*pacta.User, error)
 	User(tx db.Tx, id pacta.UserID) (*pacta.User, error)
 	Users(tx db.Tx, ids []pacta.UserID) (map[pacta.UserID]*pacta.User, error)

--- a/cmd/server/pactasrv/upload.go
+++ b/cmd/server/pactasrv/upload.go
@@ -1,0 +1,20 @@
+package pactasrv
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/RMI/pacta/openapi/pacta"
+)
+
+// Starts the process of uploading one or more portfolio files
+// (POST /portfolio-upload)
+func (s *Server) StartPortfolioUpload(ctx context.Context, request api.StartPortfolioUploadRequestObject) (api.StartPortfolioUploadResponseObject, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Called after uploads of portfolios to cloud storage are complete.
+// (POST /portfolio-upload:complete)
+func (s *Server) CompletePortfolioUpload(ctx context.Context, request api.CompletePortfolioUploadRequestObject) (api.CompletePortfolioUploadResponseObject, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -464,7 +464,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NewPortfolioAsset'
-  /startPortfolioUpload:
+  /portfolio-upload:
     post:
       summary: Starts the process of uploading one or more portfolio files
       description: Creates one or more new incomplete portfolio uploads, and creates upload URLs for the user to put their blobs into.
@@ -475,15 +475,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/StartPortfolioUploadRequest'
+              $ref: '#/components/schemas/StartPortfolioUploadReq'
       responses:
         '200':
           description: The assets can now be uploaded via the given signed URLs.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StartPortfolioUploadResponse'
-  /completePortfolioUpload:
+                $ref: '#/components/schemas/StartPortfolioUploadResp'
+  /portfolio-upload:complete:
     post:
       summary: Called after uploads of portfolios to cloud storage are complete.
       description: Signals that the upload of the portfolios are complete, and that the server should start parsing them.
@@ -494,14 +494,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CompletePortfolioUploadRequest'
+              $ref: '#/components/schemas/CompletePortfolioUploadReq'
       responses:
         '200':
           description: The process to initiate the parsing of the uploads has been initiated.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CompletePortfolioUploadResponse'
+                $ref: '#/components/schemas/CompletePortfolioUploadResp'
   /test:parsePortfolio:
     post:
       summary: Test endpoint, triggers a task to parse the portfolio
@@ -876,7 +876,7 @@ components:
         asset_id:
           type: string
           description: A unique identifier for the uploaded asset
-    StartPortfolioUploadRequest:
+    StartPortfolioUploadReq:
       type: object
       required:
         - items
@@ -884,8 +884,8 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/StartPortfolioUploadRequestItem'
-    StartPortfolioUploadRequestItem:
+            $ref: '#/components/schemas/StartPortfolioUploadReqItem'
+    StartPortfolioUploadReqItem:
       type: object
       required:
         - file_name
@@ -893,7 +893,7 @@ components:
         file_name:
           type: string
           description: The name of the file, including its extension.
-    StartPortfolioUploadResponse:
+    StartPortfolioUploadResp:
       type: object
       required:
         - items
@@ -901,8 +901,8 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/StartPortfolioUploadResponseItem'
-    StartPortfolioUploadResponseItem:
+            $ref: '#/components/schemas/StartPortfolioUploadRespItem'
+    StartPortfolioUploadRespItem:
       type: object
       required:
         - file_name
@@ -918,17 +918,25 @@ components:
         incomplete_upload_id:
           type: string
           description: A unique identifier for the uploaded asset
-    CompletePortfolioUpload:
+    CompletePortfolioUploadReq:
       type: object
       required:
-        - incomplete_upload_ids
+        - items
       properties:
-        incomplete_upload_ids:
+        items:
           type: array
           items:
-            type: string
-          description: The incomplete uploads that have been successfully uploaded and are ready for parsing.
-    CompletePortfolioUpload:
+            $ref: '#/components/schemas/CompletePortfolioUploadReqItem'
+          description: The incomplete uploads that have been successfully uploaded to storage and are ready for parsing.
+    CompletePortfolioUploadReqItem:
+      type: object
+      required:
+        - incomplete_upload_id
+      properties:
+        incomplete_upload_id:
+          type: string
+          description: The unique identifier for the uploaded asset
+    CompletePortfolioUploadResp:
       type: object
       required:
         - analysis_id

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -464,6 +464,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NewPortfolioAsset'
+  /startPortfolioUpload:
+    post:
+      summary: Starts the process of uploading one or more portfolio files
+      description: Creates one or more new incomplete portfolio uploads, and creates upload URLs for the user to put their blobs into.
+      operationId: startPortfolioUpload
+      requestBody:
+        description: A request describing the portfolios that the user wants to upload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartPortfolioUploadRequest'
+      responses:
+        '200':
+          description: The assets can now be uploaded via the given signed URLs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StartPortfolioUploadResponse'
+  /completePortfolioUpload:
+    post:
+      summary: Called after uploads of portfolios to cloud storage are complete.
+      description: Signals that the upload of the portfolios are complete, and that the server should start parsing them.
+      operationId: completePortfolioUpload
+      requestBody:
+        description: A request describing the incomplete uploads that the user wants to begin processing
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompletePortfolioUploadRequest'
+      responses:
+        '200':
+          description: The process to initiate the parsing of the uploads has been initiated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompletePortfolioUploadResponse'
   /test:processPortfolio:
     post:
       summary: Test endpoint, triggers a task to process the portfolio
@@ -838,6 +876,66 @@ components:
         asset_id:
           type: string
           description: A unique identifier for the uploaded asset
+    StartPortfolioUploadRequest:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/StartPortfolioUploadRequestItem'
+    StartPortfolioUploadRequestItem:
+      type: object
+      required:
+        - file_name
+      properties:
+        file_name:
+          type: string
+          description: The name of the file, including its extension.
+    StartPortfolioUploadResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/StartPortfolioUploadResponseItem'
+    StartPortfolioUploadResponseItem:
+      type: object
+      required:
+        - file_name
+        - upload_url
+        - incomplete_upload_id
+      properties:
+        file_name:
+          type: string
+          description: The name of the file, including its extension, used as a round-trip id.
+        upload_url:
+          type: string
+          description: The signed URL where the file should be uploaded to, using PUT semantics.
+        incomplete_upload_id:
+          type: string
+          description: A unique identifier for the uploaded asset
+    CompletePortfolioUpload:
+      type: object
+      required:
+        - incomplete_upload_ids
+      properties:
+        incomplete_upload_ids:
+          type: array
+          items:
+            type: string
+          description: The incomplete uploads that have been successfully uploaded and are ready for parsing.
+    CompletePortfolioUpload:
+      type: object
+      required:
+        - analysis_id
+      properties:
+        analysis_id:
+          type: string
+          description: The analysis id to track for the parsing task.
     ProcessPortfolioReq:
       type: object
       required:


### PR DESCRIPTION
The request is two step: (a) create the upload URLs and blobs, then after the assets are uploaded (b) kick off a process for parsing explicitly.

Sending the PR for the interface first - trying to get smaller ones going.