### PR TITLE
Audit Log API Layer

### DIFF
--- a/cmd/server/pactasrv/BUILD.bazel
+++ b/cmd/server/pactasrv/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "pactasrv",
     srcs = [
+        "audit_logs.go",
         "incomplete_upload.go",
         "initiative.go",
         "initiative_invitation.go",

--- a/cmd/server/pactasrv/audit_logs.go
+++ b/cmd/server/pactasrv/audit_logs.go
@@ -17,7 +17,8 @@ func (s *Server) ListAuditLogs(ctx context.Context, request api.ListAuditLogsReq
 	if err != nil {
 		return nil, err
 	}
-	// TODO(#12) implement additional authorization, ensuring for example that:
+	// TODO(#12) implement additional authorizations, ensuring for example that:
+	// - every generated query has reasonable limits + only filters by allowed search terms
 	// - the actor is allowed to see the audit logs of the actor_owner, but not of other actor_owners
 	// - initiative admins should be able to see audit logs of the initiative, but not initiative members
 	// - admins should be able to see all

--- a/cmd/server/pactasrv/audit_logs.go
+++ b/cmd/server/pactasrv/audit_logs.go
@@ -1,0 +1,38 @@
+package pactasrv
+
+import (
+	"context"
+
+	"github.com/RMI/pacta/cmd/server/pactasrv/conv"
+	"github.com/RMI/pacta/oapierr"
+	api "github.com/RMI/pacta/openapi/pacta"
+	"go.uber.org/zap"
+)
+
+// queries the platform's audit logs
+// (POST /audit-logs)
+func (s *Server) ListAuditLogs(ctx context.Context, request api.ListAuditLogsRequestObject) (api.ListAuditLogsResponseObject, error) {
+	// TODO(#12) implement authorization
+	query, err := conv.AuditLogQueryFromOAPI(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(#12) implement additional authorization, ensuring for example that:
+	// - the actor is allowed to see the audit logs of the actor_owner, but not of other actor_owners
+	// - initiative admins should be able to see audit logs of the initiative, but not initiative members
+	// - admins should be able to see all
+	// This is probably our most important piece of authz-ery, so it should be thoroughly tested.
+	als, pi, err := s.DB.AuditLogs(s.DB.NoTxn(ctx), query)
+	if err != nil {
+		return nil, oapierr.Internal("querying audit logs failed", zap.Error(err))
+	}
+	results, err := dereference(conv.AuditLogsToOAPI(als))
+	if err != nil {
+		return nil, err
+	}
+	return api.ListAuditLogs200JSONResponse{
+		AuditLogs:   results,
+		Cursor:      string(pi.Cursor),
+		HasNextPage: pi.HasNextPage,
+	}, nil
+}

--- a/cmd/server/pactasrv/conv/BUILD.bazel
+++ b/cmd/server/pactasrv/conv/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/RMI/pacta/cmd/server/pactasrv/conv",
     visibility = ["//visibility:public"],
     deps = [
+        "//db",
         "//oapierr",
         "//openapi:pacta_generated",
         "//pacta",

--- a/cmd/server/pactasrv/conv/helpers.go
+++ b/cmd/server/pactasrv/conv/helpers.go
@@ -10,6 +10,14 @@ func strPtr[T ~string](t T) *string {
 	return ptr(string(t))
 }
 
+func fromStrs[T ~string](ss []string) []T {
+	result := make([]T, len(ss))
+	for i, s := range ss {
+		result[i] = T(s)
+	}
+	return result
+}
+
 func ifNil[T any](t *T, fallback T) T {
 	if t == nil {
 		return fallback

--- a/cmd/server/pactasrv/conv/oapi_to_pacta.go
+++ b/cmd/server/pactasrv/conv/oapi_to_pacta.go
@@ -1,8 +1,10 @@
 package conv
 
 import (
+	"fmt"
 	"regexp"
 
+	"github.com/RMI/pacta/db"
 	"github.com/RMI/pacta/oapierr"
 	api "github.com/RMI/pacta/openapi/pacta"
 	"github.com/RMI/pacta/pacta"
@@ -90,5 +92,111 @@ func PortfolioGroupCreateFromOAPI(pg *api.PortfolioGroupCreate, ownerID pacta.Ow
 		Name:        pg.Name,
 		Description: pg.Description,
 		Owner:       &pacta.Owner{ID: ownerID},
+	}, nil
+}
+
+func auditLogActionFromOAPI(i api.AuditLogAction) (pacta.AuditLogAction, error) {
+	return pacta.ParseAuditLogAction(string(i))
+}
+
+func auditLogActorTypeFromOAPI(i api.AuditLogActorType) (pacta.AuditLogActorType, error) {
+	return pacta.ParseAuditLogActorType(string(i))
+}
+
+func auditLogTargetTypeFromOAPI(i api.AuditLogTargetType) (pacta.AuditLogTargetType, error) {
+	return pacta.ParseAuditLogTargetType(string(i))
+}
+
+func auditLogQueryWhereFromOAPI(i api.AuditLogQueryWhere) (*db.AuditLogQueryWhere, error) {
+	result := &db.AuditLogQueryWhere{}
+	if i.InId != nil {
+		result.InID = fromStrs[pacta.AuditLogID](*i.InId)
+	}
+	if i.MinCreatedAt != nil {
+		result.MinCreatedAt = *i.MinCreatedAt
+	}
+	if i.MaxCreatedAt != nil {
+		result.MaxCreatedAt = *i.MaxCreatedAt
+	}
+	if i.InAction != nil {
+		as, err := convAll(*i.InAction, auditLogActionFromOAPI)
+		if err != nil {
+			return nil, fmt.Errorf("converting audit log query where in action: %w", err)
+		}
+		result.InAction = as
+	}
+	if i.InActorType != nil {
+		at, err := convAll(*i.InActorType, auditLogActorTypeFromOAPI)
+		if err != nil {
+			return nil, fmt.Errorf("converting audit log query where in actor type: %w", err)
+		}
+		result.InActorType = at
+	}
+	if i.InActorId != nil {
+		result.InActorID = *i.InActorId
+	}
+	if i.InActorOwnerId != nil {
+		result.InActorOwnerID = fromStrs[pacta.OwnerID](*i.InActorOwnerId)
+	}
+	if i.InTargetType != nil {
+		tt, err := convAll(*i.InTargetType, auditLogTargetTypeFromOAPI)
+		if err != nil {
+			return nil, fmt.Errorf("converting audit log query where in target type: %w", err)
+		}
+		result.InTargetType = tt
+	}
+	if i.InTargetId != nil {
+		result.InTargetID = *i.InTargetId
+	}
+	if i.InTargetOwnerId != nil {
+		result.InTargetOwnerID = fromStrs[pacta.OwnerID](*i.InTargetOwnerId)
+	}
+	return result, nil
+}
+
+func auditLogQuerySortByFromOAPI(i api.AuditLogQuerySortBy) (db.AuditLogQuerySortBy, error) {
+	return db.ParseAuditLogQuerySortBy(string(i))
+}
+
+func auditLogQuerySortFromOAPI(i api.AuditLogQuerySort) (*db.AuditLogQuerySort, error) {
+	by, err := auditLogQuerySortByFromOAPI(i.By)
+	if err != nil {
+		return nil, fmt.Errorf("converting audit log query sort by: %w", err)
+	}
+	return &db.AuditLogQuerySort{
+		By:        by,
+		Ascending: i.Ascending,
+	}, nil
+}
+
+func AuditLogQueryFromOAPI(q *api.AuditLogQueryReq) (*db.AuditLogQuery, error) {
+	limit := 25
+	if q.Limit != nil {
+		limit = *q.Limit
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	cursor := ""
+	if q.Cursor != nil {
+		cursor = *q.Cursor
+	}
+	sorts := []*db.AuditLogQuerySort{}
+	if q.Sorts != nil {
+		ss, err := convAll(*q.Sorts, auditLogQuerySortFromOAPI)
+		if err != nil {
+			return nil, oapierr.BadRequest("error converting audit log query sorts", zap.Error(err))
+		}
+		sorts = ss
+	}
+	wheres, err := convAll(q.Wheres, auditLogQueryWhereFromOAPI)
+	if err != nil {
+		return nil, oapierr.BadRequest("error converting audit log query wheres", zap.Error(err))
+	}
+	return &db.AuditLogQuery{
+		Cursor: db.Cursor(cursor),
+		Limit:  limit,
+		Wheres: wheres,
+		Sorts:  sorts,
 	}, nil
 }

--- a/cmd/server/pactasrv/conv/pacta_to_oapi.go
+++ b/cmd/server/pactasrv/conv/pacta_to_oapi.go
@@ -1,6 +1,8 @@
 package conv
 
 import (
+	"fmt"
+
 	"github.com/RMI/pacta/oapierr"
 	api "github.com/RMI/pacta/openapi/pacta"
 	"github.com/RMI/pacta/pacta"
@@ -238,15 +240,65 @@ func PortfolioGroupsToOAPI(pgs []*pacta.PortfolioGroup) ([]*api.PortfolioGroup, 
 }
 
 func auditLogActorTypeToOAPI(i pacta.AuditLogActorType) (api.AuditLogActorType, error) {
-	return api.AuditLogActorType(string(i)), nil
+	switch i {
+	case pacta.AuditLogActorType_Public:
+		return api.AuditLogActorTypePUBLIC, nil
+	case pacta.AuditLogActorType_Owner:
+		return api.AuditLogActorTypeOWNER, nil
+	case pacta.AuditLogActorType_Admin:
+		return api.AuditLogActorTypeADMIN, nil
+	case pacta.AuditLogActorType_SuperAdmin:
+		return api.AuditLogActorTypeSUPERADMIN, nil
+	case pacta.AuditLogActorType_System:
+		return api.AuditLogActorTypeSYSTEM, nil
+	}
+	return "", oapierr.Internal(fmt.Sprintf("auditLogActorTypeToOAPI: unknown actor type: %q", i))
 }
 
 func auditLogActionToOAPI(i pacta.AuditLogAction) (api.AuditLogAction, error) {
-	return api.AuditLogAction(string(i)), nil
+	switch i {
+	case pacta.AuditLogAction_Create:
+		return api.AuditLogActionCREATE, nil
+	case pacta.AuditLogAction_Update:
+		return api.AuditLogActionUPDATE, nil
+	case pacta.AuditLogAction_Delete:
+		return api.AuditLogActionDELETE, nil
+	case pacta.AuditLogAction_AddTo:
+		return api.AuditLogActionADDTO, nil
+	case pacta.AuditLogAction_RemoveFrom:
+		return api.AuditLogActionREMOVEFROM, nil
+	case pacta.AuditLogAction_EnableAdminDebug:
+		return api.AuditLogActionENABLEADMINDEBUG, nil
+	case pacta.AuditLogAction_DisableAdminDebug:
+		return api.AuditLogActionDISABLEADMINDEBUG, nil
+	case pacta.AuditLogAction_Download:
+		return api.AuditLogActionDOWNLOAD, nil
+	case pacta.AuditLogAction_EnableSharing:
+		return api.AuditLogActionENABLESHARING, nil
+	case pacta.AuditLogAction_DisableSharing:
+		return api.AuditLogActionDISABLESHARING, nil
+	}
+	return "", oapierr.Internal(fmt.Sprintf("auditLogActionToOAPI: unknown action: %q", i))
 }
 
 func auditLogTargetTypeToOAPI(i pacta.AuditLogTargetType) (api.AuditLogTargetType, error) {
-	return api.AuditLogTargetType(string(i)), nil
+	switch i {
+	case pacta.AuditLogTargetType_User:
+		return api.AuditLogTargetTypeUSER, nil
+	case pacta.AuditLogTargetType_Portfolio:
+		return api.AuditLogTargetTypePORTFOLIO, nil
+	case pacta.AuditLogTargetType_IncompleteUpload:
+		return api.AuditLogTargetTypeINCOMPLETEUPLOAD, nil
+	case pacta.AuditLogTargetType_PortfolioGroup:
+		return api.AuditLogTargetTypePORTFOLIOGROUP, nil
+	case pacta.AuditLogTargetType_Initiative:
+		return api.AuditLogTargetTypeINITIATIVE, nil
+	case pacta.AuditLogTargetType_PACTAVersion:
+		return api.AuditLogTargetTypePACTAVERSION, nil
+	case pacta.AuditLogTargetType_Analysis:
+		return api.AuditLogTargetTypeANALYSIS, nil
+	}
+	return "", oapierr.Internal(fmt.Sprintf("auditLogTargetTypeToOAPI: unknown target type: %q", i))
 }
 
 func AuditLogToOAPI(al *pacta.AuditLog) (*api.AuditLog, error) {

--- a/cmd/server/pactasrv/pactasrv.go
+++ b/cmd/server/pactasrv/pactasrv.go
@@ -93,6 +93,8 @@ type DB interface {
 	CreatePortfolioGroupMembership(tx db.Tx, pgID pacta.PortfolioGroupID, pID pacta.PortfolioID) error
 	DeletePortfolioGroupMembership(tx db.Tx, pgID pacta.PortfolioGroupID, pID pacta.PortfolioID) error
 
+	AuditLogs(tx db.Tx, q *db.AuditLogQuery) ([]*pacta.AuditLog, *db.PageInfo, error)
+
 	GetOrCreateUserByAuthn(tx db.Tx, mech pacta.AuthnMechanism, authnID, email, canonicalEmail string) (*pacta.User, error)
 	User(tx db.Tx, id pacta.UserID) (*pacta.User, error)
 	Users(tx db.Tx, ids []pacta.UserID) (map[pacta.UserID]*pacta.User, error)

--- a/db/queries.go
+++ b/db/queries.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/RMI/pacta/pacta"
@@ -28,6 +29,32 @@ const (
 	AuditLogQuerySortBy_SecondaryTargetOwnerID AuditLogQuerySortBy = "secondary_target_owner_id"
 )
 
+func ParseAuditLogQuerySortBy(s string) (AuditLogQuerySortBy, error) {
+	switch s {
+	case "created_at":
+		return AuditLogQuerySortBy_CreatedAt, nil
+	case "actor_type":
+		return AuditLogQuerySortBy_ActorType, nil
+	case "actor_id":
+		return AuditLogQuerySortBy_ActorID, nil
+	case "actor_owner_id":
+		return AuditLogQuerySortBy_ActorOwnerID, nil
+	case "primary_target_id":
+		return AuditLogQuerySortBy_PrimaryTargetID, nil
+	case "primary_target_type":
+		return AuditLogQuerySortBy_PrimaryTargetType, nil
+	case "primary_target_owner_id":
+		return AuditLogQuerySortBy_PrimaryTargetOwnerID, nil
+	case "secondary_target_id":
+		return AuditLogQuerySortBy_SecondaryTargetID, nil
+	case "secondary_target_type":
+		return AuditLogQuerySortBy_SecondaryTargetType, nil
+	case "secondary_target_owner_id":
+		return AuditLogQuerySortBy_SecondaryTargetOwnerID, nil
+	}
+	return "", fmt.Errorf("unknown ParseAuditLogActorType: %q", s)
+}
+
 type AuditLogQuerySort struct {
 	By        AuditLogQuerySortBy
 	Ascending bool
@@ -37,7 +64,7 @@ type AuditLogQueryWhere struct {
 	InID            []pacta.AuditLogID
 	MinCreatedAt    time.Time
 	MaxCreatedAt    time.Time
-	InActionType    []pacta.AuditLogAction
+	InAction        []pacta.AuditLogAction
 	InActorType     []pacta.AuditLogActorType
 	InActorID       []string
 	InActorOwnerID  []pacta.OwnerID

--- a/db/sqldb/audit_log.go
+++ b/db/sqldb/audit_log.go
@@ -207,8 +207,8 @@ func auditLogQueryWheresToSQL(qs []*db.AuditLogQueryWhere, args *queryArgs) stri
 		if len(q.InID) > 0 {
 			wheres = append(wheres, eqOrIn("audit_log.id", q.InID, args))
 		}
-		if len(q.InActionType) > 0 {
-			wheres = append(wheres, eqOrIn("audit_log.action", q.InActionType, args))
+		if len(q.InAction) > 0 {
+			wheres = append(wheres, eqOrIn("audit_log.action", q.InAction, args))
 		}
 		if !q.MinCreatedAt.IsZero() {
 			wheres = append(wheres, "audit_log.created_at >= "+args.add(q.MinCreatedAt))

--- a/db/sqldb/audit_log_test.go
+++ b/db/sqldb/audit_log_test.go
@@ -19,7 +19,7 @@ func TestCreateAuditLog(t *testing.T) {
 	cmpOpts := auditLogCmpOpts()
 	al := &pacta.AuditLog{
 		Action:               pacta.AuditLogAction_AddTo,
-		ActorType:            pacta.AuditLogActorType_User,
+		ActorType:            pacta.AuditLogActorType_Owner,
 		ActorID:              "user1",
 		ActorOwner:           &pacta.Owner{ID: "owner1"},
 		PrimaryTargetType:    pacta.AuditLogTargetType_Portfolio,
@@ -88,7 +88,7 @@ func testAuditLogEnumConvertability[E comparable](t *testing.T, writeE func(E, *
 	tx := tdb.NoTxn(ctx)
 	base := &pacta.AuditLog{
 		Action:               pacta.AuditLogAction_AddTo,
-		ActorType:            pacta.AuditLogActorType_User,
+		ActorType:            pacta.AuditLogActorType_Owner,
 		ActorID:              "user1",
 		ActorOwner:           &pacta.Owner{ID: "owner1"},
 		PrimaryTargetType:    pacta.AuditLogTargetType_Portfolio,
@@ -127,7 +127,7 @@ func TestAuditSearch(t *testing.T) {
 	beforeCreation := time.Now()
 	action1 := pacta.AuditLogAction_AddTo
 	action2 := pacta.AuditLogAction_Create
-	actorType1 := pacta.AuditLogActorType_User
+	actorType1 := pacta.AuditLogActorType_Owner
 	actorType2 := pacta.AuditLogActorType_System
 	actorID1 := "user1"
 	actorID2 := "system2"
@@ -177,7 +177,7 @@ func TestAuditSearch(t *testing.T) {
 			expected: []pacta.AuditLogID{alID1, alID2, alID3},
 		}, {
 			name:     "By ActionType",
-			where:    &db.AuditLogQueryWhere{InActionType: []pacta.AuditLogAction{action2}},
+			where:    &db.AuditLogQueryWhere{InAction: []pacta.AuditLogAction{action2}},
 			expected: []pacta.AuditLogID{alID2, alID3},
 		}, {
 			name:     "By ActorType",
@@ -240,7 +240,7 @@ func TestAuditSearch(t *testing.T) {
 				&db.AuditLogQueryWhere{InID: []pacta.AuditLogID{alID1}},
 				&db.AuditLogQueryWhere{MinCreatedAt: beforeCreation},
 				&db.AuditLogQueryWhere{MaxCreatedAt: afterCreation},
-				&db.AuditLogQueryWhere{InActionType: []pacta.AuditLogAction{action1}},
+				&db.AuditLogQueryWhere{InAction: []pacta.AuditLogAction{action1}},
 				&db.AuditLogQueryWhere{InActorType: []pacta.AuditLogActorType{actorType1}},
 				&db.AuditLogQueryWhere{InActorID: []string{actorID1}},
 				&db.AuditLogQueryWhere{InActorOwnerID: []pacta.OwnerID{actorOwner1.ID}},
@@ -255,7 +255,7 @@ func TestAuditSearch(t *testing.T) {
 				&db.AuditLogQueryWhere{InID: []pacta.AuditLogID{alID1}},
 				&db.AuditLogQueryWhere{MinCreatedAt: beforeCreation},
 				&db.AuditLogQueryWhere{MaxCreatedAt: afterCreation},
-				&db.AuditLogQueryWhere{InActionType: []pacta.AuditLogAction{action1}},
+				&db.AuditLogQueryWhere{InAction: []pacta.AuditLogAction{action1}},
 				&db.AuditLogQueryWhere{InActorType: []pacta.AuditLogActorType{actorType2}},
 				&db.AuditLogQueryWhere{InActorID: []string{actorID1}},
 				&db.AuditLogQueryWhere{InActorOwnerID: []pacta.OwnerID{actorOwner1.ID}},

--- a/db/sqldb/golden/human_readable_schema.sql
+++ b/db/sqldb/golden/human_readable_schema.sql
@@ -23,7 +23,9 @@ CREATE TYPE audit_log_actor_type AS ENUM (
     'USER',
     'ADMIN',
     'SUPER_ADMIN',
-    'SYSTEM');
+    'SYSTEM',
+    'OWNER',
+    'PUBLIC');
 CREATE TYPE audit_log_target_type AS ENUM (
     'USER',
     'PORTFOLIO',

--- a/db/sqldb/golden/schema_dump.sql
+++ b/db/sqldb/golden/schema_dump.sql
@@ -56,7 +56,9 @@ CREATE TYPE public.audit_log_actor_type AS ENUM (
     'USER',
     'ADMIN',
     'SUPER_ADMIN',
-    'SYSTEM'
+    'SYSTEM',
+    'OWNER',
+    'PUBLIC'
 );
 
 

--- a/db/sqldb/migrations/0007_audit_log_actor_type.down.sql
+++ b/db/sqldb/migrations/0007_audit_log_actor_type.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+-- There isn't a way to delete a value from an enum, so this is the workaround
+-- https://stackoverflow.com/a/56777227/17909149
+
+ALTER TABLE audit_log ALTER actor_type TYPE TEXT;
+
+DROP TYPE audit_log_actor_type;
+CREATE TYPE audit_log_actor_type AS ENUM (
+    'USER',
+    'ADMIN',
+    'SUPER_ADMIN',
+    'SYSTEM');
+
+ALTER TABLE audit_log
+    ALTER actor_type TYPE actor_type 
+        USING actor_type::actor_type;
+
+COMMIT;

--- a/db/sqldb/migrations/0007_audit_log_actor_type.up.sql
+++ b/db/sqldb/migrations/0007_audit_log_actor_type.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TYPE audit_log_actor_type ADD VALUE 'OWNER';
+ALTER TYPE audit_log_actor_type ADD VALUE 'PUBLIC'; 
+
+COMMIT;

--- a/db/sqldb/sqldb_test.go
+++ b/db/sqldb/sqldb_test.go
@@ -88,6 +88,7 @@ func TestSchemaHistory(t *testing.T) {
 		{ID: 4, Version: 4}, // 0004_audit_log_tweaks
 		{ID: 5, Version: 5}, // 0005_json_blob_type
 		{ID: 6, Version: 6}, // 0006_initiative_primary_key
+		{ID: 7, Version: 7}, // 0007_audit_log_actor_type
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -1498,7 +1498,7 @@ components:
         - AuditLogAction_UPDATE
         - AuditLogAction_DELETE
         - AuditLogAction_ADD_TO
-        - AuditLogAction_REMOVE_FROMO
+        - AuditLogAction_REMOVE_FROM
         - AuditLogAction_ENABLE_ADMIN_DEBUG
         - AuditLogAction_DISABLE_ADMIN_DEBUG
         - AuditLogAction_DOWNLOAD
@@ -1515,13 +1515,13 @@ components:
     AuditLogTargetType:
       type: string
       enum:
-        - AuditLogActorType_USER
-        - AuditLogActorType_PORTFOLIO
-        - AuditLogActorType_INCOMPLETE_UPLOAD
-        - AuditLogActorType_PORTFOLIO_GROUP
-        - AuditLogActorType_INITIATIVE
-        - AuditLogActorType_PACTA_VERSION
-        - AuditLogActorType_ANALYSIS
+        - AuditLogTargetType_USER
+        - AuditLogTargetType_PORTFOLIO
+        - AuditLogTargetType_INCOMPLETE_UPLOAD
+        - AuditLogTargetType_PORTFOLIO_GROUP
+        - AuditLogTargetType_INITIATIVE
+        - AuditLogTargetType_PACTA_VERSION
+        - AuditLogTargetType_ANALYSIS
     AuditLogQueryWhere:
       type: object
       properties:

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -730,6 +730,25 @@ paths:
       responses:
         '204':
           description: user deleted
+  /audit-logs:
+    post:
+      summary: queries the platform's audit logs
+      description: returns back audit logs that matc the user's query 
+      operationId: listAuditLogs 
+      requestBody:
+        description: A request describing which audit logs should be returned 
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditLogQueryReq'
+      responses:
+        '200':
+          description: The audit logs that matched the requested query, if any 
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogQueryResp'
   /portfolio-upload:
     post:
       summary: Starts the process of uploading one or more portfolio files
@@ -1472,6 +1491,198 @@ components:
         task_id:
           type: string
           description: The ID of the async task for processing the portfoio
+    AuditLogAction:
+      type: string
+      enum:
+        - AuditLogAction_CREATE
+        - AuditLogAction_UPDATE
+        - AuditLogAction_DELETE
+        - AuditLogAction_ADD_TO
+        - AuditLogAction_REMOVE_FROMO
+        - AuditLogAction_ENABLE_ADMIN_DEBUG
+        - AuditLogAction_DISABLE_ADMIN_DEBUG
+        - AuditLogAction_DOWNLOAD
+        - AuditLogAction_ENABLE_SHARING
+        - AuditLogAction_DISABLE_SHARING
+    AuditLogActorType:
+      type: string
+      enum:
+        - AuditLogActorType_PUBLIC
+        - AuditLogActorType_OWNER
+        - AuditLogActorType_ADMIN
+        - AuditLogActorType_SUPER_ADMIN
+        - AuditLogActorType_SYSTEM
+    AuditLogTargetType:
+      type: string
+      enum:
+        - AuditLogActorType_USER
+        - AuditLogActorType_PORTFOLIO
+        - AuditLogActorType_INCOMPLETE_UPLOAD
+        - AuditLogActorType_PORTFOLIO_GROUP
+        - AuditLogActorType_INITIATIVE
+        - AuditLogActorType_PACTA_VERSION
+        - AuditLogActorType_ANALYSIS
+    AuditLogQueryWhere:
+      type: object
+      properties:
+        inId:
+          type: array
+          description: a list of audit log ids to filter by
+          items: 
+            type: string
+        minCreatedAt:
+          type: string
+          format: date-time 
+          description: a minimum time for audit logs to filter audit logs by 
+        maxCreatedAt:
+          type: string
+          format: date-time 
+          description: a maximum time for audit logs to filter audit logs by 
+        inAction:
+          type: array
+          description: a list of audit log action types to filter audit logs by 
+          items: 
+            $ref: '#/components/schemas/AuditLogAction'
+        inActorType:
+          type: array
+          description: a list of audit log actor types to filter audit logs by 
+          items: 
+            $ref: '#/components/schemas/AuditLogActorType'
+        inActorId:
+          type: array
+          description: a list of actor user ids to filter audit logs by
+          items: 
+            type: string
+        inActorOwnerId:
+          type: array
+          description: a list of actor owner ids to filter audit logs by
+          items: 
+            type: string
+        inTargetType:
+          type: array
+          description: a list of audit log target types to filter audit logs by 
+          items: 
+            $ref: '#/components/schemas/AuditLogTargetType'
+        inTargetId:
+          type: array
+          description: a list of target ids to filter audit logs by 
+          items: 
+            type: string
+        inTargetOwnerId:
+          type: array
+          description: a list of target owner ids to filter audit logs by 
+          items: 
+            type: string
+    AuditLogQuerySortBy:
+      type: string
+      enum:
+        - AuditLogQuerySortBy_CREATED_AT
+        - AuditLogQuerySortBy_ACTOR_TYPE
+        - AuditLogQuerySortBy_ACTOR_ID
+        - AuditLogQuerySortBy_ACTOR_OWNER_ID
+        - AuditLogQuerySortBy_PRIMARY_TARGET_ID
+        - AuditLogQuerySortBy_PRIMARY_TARGET_TYPE
+        - AuditLogQuerySortBy_PRIMARY_TARGET_OWNER_ID
+        - AuditLogQuerySortBy_SECONDARY_TARGET_ID
+        - AuditLogQuerySortBy_SECONDARY_TARGET_TYPE
+        - AuditLogQuerySortBy_SECONDARY_TARGET_OWNER_ID
+    AuditLogQuerySort:
+      type: object
+      required:
+        - by
+        - ascending
+      properties:
+        by:
+          $ref: '#/components/schemas/AuditLogQuerySortBy'
+        ascending:
+          type: boolean
+          description: whether the sort should be ascending or descending
+    AuditLogQueryReq:
+      type: object
+      required:
+        - wheres
+      properties:
+        cursor:
+          type: string
+          description: if provided, continues an existing query at the given point 
+        limit: 
+          type: integer
+          description: if provided, requests this number of records at maximum - default/maximum is 100
+        wheres:
+          type: array 
+          description: the constraints to place on the returned records - this must be set to something which limits it to a scope the user should have access to
+          items: 
+            $ref: '#/components/schemas/AuditLogQueryWhere'
+        sorts:
+          type: array 
+          description: the ordering that the results should be returned in - if empty, an ordering by created at date will be applied 
+          items: 
+            $ref: '#/components/schemas/AuditLogQuerySort'
+    AuditLogQueryResp:
+      type: object
+      required:
+        - auditLogs
+        - cursor
+        - hasNextPage
+      properties:
+        auditLogs:
+          type: array
+          items: 
+            $ref: '#/components/schemas/AuditLog'
+        hasNextPage:
+          type: boolean
+          description: describes whether there are more records to query
+        cursor:
+          type: string
+          description: the parameter to re-request with to continue this query on the next page of results 
+    AuditLog:
+      type: object
+      required:
+        - id
+        - createdAt
+        - actorType
+        - action
+        - primaryTargetType
+        - primaryTargetId
+        - primaryTargetOwner
+      properties:
+        id:
+          type: string
+          description: the unique identifier of a given audit log
+        createdAt:
+          type: string
+          format: date-time
+          description: the time that this audit log was created/the action was undertaken
+        actorType:
+          description: the authority that this actor was acting as when performing this action
+          $ref: '#/components/schemas/AuditLogActorType'
+        actorId:
+          type: string
+          description: the user id of the actor that initiated this action, not populated if the system initiated the action 
+        actorOwnerId:
+          type: string
+          description: the owner id of the actor that initiated this action, not populated if the system initiated the action 
+        action:
+          description: the action that generated this audit log
+          $ref: '#/components/schemas/AuditLogAction'
+        primaryTargetType:
+          description: the object category that this action was performed on
+          $ref: '#/components/schemas/AuditLogTargetType'
+        primaryTargetId:
+          type: string
+          description: the id of the object that this action was performed on 
+        primaryTargetOwner:
+          type: string
+          description: the id of the owner of the primary object this action was performed on 
+        secondaryTargetType:
+          description: the object category of the secondary object (membership partner, typically) that this action was performed on
+          $ref: '#/components/schemas/AuditLogTargetType'
+        secondaryTargetId:
+          type: string
+          description: the id of the secondary object that this action was performed on 
+        secondaryTargetOwner:
+          type: string
+          description: the id of the owner of the secondary object this action was performed on
     Error:
       type: object
       required:

--- a/pacta/pacta.go
+++ b/pacta/pacta.go
@@ -602,14 +602,16 @@ func ParseAuditLogAction(s string) (AuditLogAction, error) {
 type AuditLogActorType string
 
 const (
-	AuditLogActorType_User       AuditLogActorType = "USER"
+	AuditLogActorType_Public     AuditLogActorType = "PUBLIC"
+	AuditLogActorType_Owner      AuditLogActorType = "OWNER"
 	AuditLogActorType_Admin      AuditLogActorType = "ADMIN"
 	AuditLogActorType_SuperAdmin AuditLogActorType = "SUPER_ADMIN"
 	AuditLogActorType_System     AuditLogActorType = "SYSTEM"
 )
 
 var AuditLogActorTypeValues = []AuditLogActorType{
-	AuditLogActorType_User,
+	AuditLogActorType_Public,
+	AuditLogActorType_Owner,
 	AuditLogActorType_Admin,
 	AuditLogActorType_SuperAdmin,
 	AuditLogActorType_System,
@@ -617,8 +619,10 @@ var AuditLogActorTypeValues = []AuditLogActorType{
 
 func ParseAuditLogActorType(s string) (AuditLogActorType, error) {
 	switch s {
-	case "USER":
-		return AuditLogActorType_User, nil
+	case "PUBLIC":
+		return AuditLogActorType_Public, nil
+	case "OWNER":
+		return AuditLogActorType_Owner, nil
 	case "ADMIN":
 		return AuditLogActorType_Admin, nil
 	case "SUPER_ADMIN":


### PR DESCRIPTION
- Creates API layer for Audit Log Queries (largely mirroring the database layer - I'm thinking of how lovely and useful that approach was for ABOUND, and seeking to replicate it here, albeit for likely a less user-visible use case).
- Tweaks a few things I got wrong in the initial audit log design:
  - we want the `ActorType` to refer to the **pathway through which the user is accessing**, rather than **the property of the user**. This unfortunately required a DB migration to add the new enum values.
  - Adds a `ParseSortBy` method to the DB Layer.
  - Tweaks naming to be more consistent with the core types.