### PR TITLE
Various Enum Fixes + Tweaks

### DIFF
--- a/cmd/server/pactasrv/conv/BUILD.bazel
+++ b/cmd/server/pactasrv/conv/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "conv",
@@ -16,4 +16,11 @@ go_library(
         "//pacta",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "conv_test",
+    srcs = ["conv_test.go"],
+    embed = [":conv"],
+    deps = ["//pacta"],
 )

--- a/cmd/server/pactasrv/conv/conv_test.go
+++ b/cmd/server/pactasrv/conv/conv_test.go
@@ -1,0 +1,39 @@
+package conv
+
+import (
+	"testing"
+
+	"github.com/RMI/pacta/pacta"
+)
+
+func TestLanguageRoundTrip(t *testing.T) {
+	testEnumConvertability(t, pacta.LanguageValues, LanguageToOAPI, LanguageFromOAPI)
+}
+
+func TestAuditLogActorTypeRoundTrip(t *testing.T) {
+	testEnumConvertability(t, pacta.AuditLogActorTypeValues, auditLogActorTypeToOAPI, auditLogActorTypeFromOAPI)
+}
+
+func TestAuditLogActionRoundTrip(t *testing.T) {
+	testEnumConvertability(t, pacta.AuditLogActionValues, auditLogActionToOAPI, auditLogActionFromOAPI)
+}
+
+func TestAuditLogTargetTypeRoundTrip(t *testing.T) {
+	testEnumConvertability(t, pacta.AuditLogTargetTypeValues, auditLogTargetTypeToOAPI, auditLogTargetTypeFromOAPI)
+}
+
+func testEnumConvertability[A comparable, B any](t *testing.T, as []A, aToB func(in A) (B, error), bToA func(in B) (A, error)) {
+	for _, a := range as {
+		b, err := aToB(a)
+		if err != nil {
+			t.Fatalf("converting from %T %q: %w", a, a, err)
+		}
+		a2, err := bToA(b)
+		if err != nil {
+			t.Fatalf("converting from %T %q: %w", b, b, err)
+		}
+		if a != a2 {
+			t.Errorf("conversion from %T %q to %T %q and back failed, returned %q", a, a, b, b, a2)
+		}
+	}
+}

--- a/cmd/server/pactasrv/conv/oapi_to_pacta.go
+++ b/cmd/server/pactasrv/conv/oapi_to_pacta.go
@@ -124,25 +124,25 @@ func PortfolioGroupCreateFromOAPI(pg *api.PortfolioGroupCreate, ownerID pacta.Ow
 
 func auditLogActionFromOAPI(i api.AuditLogAction) (pacta.AuditLogAction, error) {
 	switch i {
-	case api.AuditLogActionCREATE:
+	case api.AuditLogActionCreate:
 		return pacta.AuditLogAction_Create, nil
-	case api.AuditLogActionUPDATE:
+	case api.AuditLogActionUpdate:
 		return pacta.AuditLogAction_Update, nil
-	case api.AuditLogActionDELETE:
+	case api.AuditLogActionDelete:
 		return pacta.AuditLogAction_Delete, nil
-	case api.AuditLogActionADDTO:
+	case api.AuditLogActionAddTo:
 		return pacta.AuditLogAction_AddTo, nil
-	case api.AuditLogActionREMOVEFROM:
+	case api.AuditLogActionRemoveFrom:
 		return pacta.AuditLogAction_RemoveFrom, nil
-	case api.AuditLogActionENABLEADMINDEBUG:
+	case api.AuditLogActionEnableAdminDebug:
 		return pacta.AuditLogAction_EnableAdminDebug, nil
-	case api.AuditLogActionDISABLEADMINDEBUG:
+	case api.AuditLogActionDisableAdminDebug:
 		return pacta.AuditLogAction_DisableAdminDebug, nil
-	case api.AuditLogActionDOWNLOAD:
+	case api.AuditLogActionDownload:
 		return pacta.AuditLogAction_Download, nil
-	case api.AuditLogActionENABLESHARING:
+	case api.AuditLogActionEnableSharing:
 		return pacta.AuditLogAction_EnableSharing, nil
-	case api.AuditLogActionDISABLESHARING:
+	case api.AuditLogActionDisableSharing:
 		return pacta.AuditLogAction_DisableSharing, nil
 	}
 	return "", oapierr.BadRequest("unknown audit log action", zap.String("audit_log_action", string(i)))
@@ -150,15 +150,15 @@ func auditLogActionFromOAPI(i api.AuditLogAction) (pacta.AuditLogAction, error) 
 
 func auditLogActorTypeFromOAPI(i api.AuditLogActorType) (pacta.AuditLogActorType, error) {
 	switch i {
-	case api.AuditLogActorTypePUBLIC:
+	case api.AuditLogActorTypePublic:
 		return pacta.AuditLogActorType_Public, nil
-	case api.AuditLogActorTypeOWNER:
+	case api.AuditLogActorTypeOwner:
 		return pacta.AuditLogActorType_Owner, nil
-	case api.AuditLogActorTypeADMIN:
+	case api.AuditLogActorTypeAdmin:
 		return pacta.AuditLogActorType_Admin, nil
-	case api.AuditLogActorTypeSUPERADMIN:
+	case api.AuditLogActorTypeSuperAdmin:
 		return pacta.AuditLogActorType_SuperAdmin, nil
-	case api.AuditLogActorTypeSYSTEM:
+	case api.AuditLogActorTypeSystem:
 		return pacta.AuditLogActorType_System, nil
 	}
 	return "", oapierr.BadRequest("unknown audit log actor type", zap.String("audit_log_actor_type", string(i)))
@@ -166,19 +166,19 @@ func auditLogActorTypeFromOAPI(i api.AuditLogActorType) (pacta.AuditLogActorType
 
 func auditLogTargetTypeFromOAPI(i api.AuditLogTargetType) (pacta.AuditLogTargetType, error) {
 	switch i {
-	case api.AuditLogTargetTypeUSER:
+	case api.AuditLogTargetTypeUser:
 		return pacta.AuditLogTargetType_User, nil
-	case api.AuditLogTargetTypePORTFOLIO:
+	case api.AuditLogTargetTypePortfolio:
 		return pacta.AuditLogTargetType_Portfolio, nil
-	case api.AuditLogTargetTypeINCOMPLETEUPLOAD:
+	case api.AuditLogTargetTypeIncompleteUpload:
 		return pacta.AuditLogTargetType_IncompleteUpload, nil
-	case api.AuditLogTargetTypePORTFOLIOGROUP:
+	case api.AuditLogTargetTypePortfolioGroup:
 		return pacta.AuditLogTargetType_PortfolioGroup, nil
-	case api.AuditLogTargetTypeINITIATIVE:
+	case api.AuditLogTargetTypeInitiative:
 		return pacta.AuditLogTargetType_Initiative, nil
-	case api.AuditLogTargetTypePACTAVERSION:
+	case api.AuditLogTargetTypePactaVersion:
 		return pacta.AuditLogTargetType_PACTAVersion, nil
-	case api.AuditLogTargetTypeANALYSIS:
+	case api.AuditLogTargetTypeAnalysis:
 		return pacta.AuditLogTargetType_Analysis, nil
 	}
 	return "", oapierr.BadRequest("unknown audit log target type", zap.String("audit_log_target_type", string(i)))
@@ -233,25 +233,25 @@ func auditLogQueryWhereFromOAPI(i api.AuditLogQueryWhere) (*db.AuditLogQueryWher
 
 func auditLogQuerySortByFromOAPI(i api.AuditLogQuerySortBy) (db.AuditLogQuerySortBy, error) {
 	switch i {
-	case api.AuditLogQuerySortByCREATEDAT:
+	case api.AuditLogQuerySortByCreatedAt:
 		return db.AuditLogQuerySortBy_CreatedAt, nil
-	case api.AuditLogQuerySortByACTORTYPE:
+	case api.AuditLogQuerySortByActorType:
 		return db.AuditLogQuerySortBy_ActorType, nil
-	case api.AuditLogQuerySortByACTORID:
+	case api.AuditLogQuerySortByActorId:
 		return db.AuditLogQuerySortBy_ActorID, nil
-	case api.AuditLogQuerySortByACTOROWNERID:
+	case api.AuditLogQuerySortByActorOwnerId:
 		return db.AuditLogQuerySortBy_ActorOwnerID, nil
-	case api.AuditLogQuerySortByPRIMARYTARGETID:
+	case api.AuditLogQuerySortByPrimaryTargetId:
 		return db.AuditLogQuerySortBy_PrimaryTargetID, nil
-	case api.AuditLogQuerySortByPRIMARYTARGETTYPE:
+	case api.AuditLogQuerySortByPrimaryTargetType:
 		return db.AuditLogQuerySortBy_PrimaryTargetType, nil
-	case api.AuditLogQuerySortByPRIMARYTARGETOWNERID:
+	case api.AuditLogQuerySortByPrimaryTargetOwnerId:
 		return db.AuditLogQuerySortBy_PrimaryTargetOwnerID, nil
-	case api.AuditLogQuerySortBySECONDARYTARGETID:
+	case api.AuditLogQuerySortBySecondaryTargetId:
 		return db.AuditLogQuerySortBy_SecondaryTargetID, nil
-	case api.AuditLogQuerySortBySECONDARYTARGETTYPE:
+	case api.AuditLogQuerySortBySecondaryTargetType:
 		return db.AuditLogQuerySortBy_SecondaryTargetType, nil
-	case api.AuditLogQuerySortBySECONDARYTARGETOWNERID:
+	case api.AuditLogQuerySortBySecondaryTargetOwnerId:
 		return db.AuditLogQuerySortBy_SecondaryTargetOwnerID, nil
 	}
 	return "", oapierr.BadRequest("unknown audit log query sort by", zap.String("audit_log_query_sort_by", string(i)))

--- a/cmd/server/pactasrv/conv/oapi_to_pacta.go
+++ b/cmd/server/pactasrv/conv/oapi_to_pacta.go
@@ -13,6 +13,20 @@ import (
 
 var initiativeIDRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+func LanguageFromOAPI(l api.Language) (pacta.Language, error) {
+	switch l {
+	case api.LanguageEN:
+		return pacta.Language_EN, nil
+	case api.LanguageES:
+		return pacta.Language_ES, nil
+	case api.LanguageFR:
+		return pacta.Language_FR, nil
+	case api.LanguageDE:
+		return pacta.Language_DE, nil
+	}
+	return "", oapierr.BadRequest("unknown language", zap.String("language", string(l)))
+}
+
 func InitiativeCreateFromOAPI(i *api.InitiativeCreate) (*pacta.Initiative, error) {
 	if i == nil {
 		return nil, oapierr.BadRequest("InitiativeCreate cannot be nil")
@@ -20,9 +34,9 @@ func InitiativeCreateFromOAPI(i *api.InitiativeCreate) (*pacta.Initiative, error
 	if !initiativeIDRegex.MatchString(i.Id) {
 		return nil, oapierr.BadRequest("id must contain only alphanumeric characters, underscores, and dashes")
 	}
-	lang, err := pacta.ParseLanguage(string(i.Language))
+	lang, err := LanguageFromOAPI(i.Language)
 	if err != nil {
-		return nil, oapierr.BadRequest("failed to parse language", zap.Error(err))
+		return nil, err
 	}
 	var pv *pacta.PACTAVersion
 	if i.PactaVersion != nil {
@@ -109,15 +123,65 @@ func PortfolioGroupCreateFromOAPI(pg *api.PortfolioGroupCreate, ownerID pacta.Ow
 }
 
 func auditLogActionFromOAPI(i api.AuditLogAction) (pacta.AuditLogAction, error) {
-	return pacta.ParseAuditLogAction(string(i))
+	switch i {
+	case api.AuditLogActionCREATE:
+		return pacta.AuditLogAction_Create, nil
+	case api.AuditLogActionUPDATE:
+		return pacta.AuditLogAction_Update, nil
+	case api.AuditLogActionDELETE:
+		return pacta.AuditLogAction_Delete, nil
+	case api.AuditLogActionADDTO:
+		return pacta.AuditLogAction_AddTo, nil
+	case api.AuditLogActionREMOVEFROM:
+		return pacta.AuditLogAction_RemoveFrom, nil
+	case api.AuditLogActionENABLEADMINDEBUG:
+		return pacta.AuditLogAction_EnableAdminDebug, nil
+	case api.AuditLogActionDISABLEADMINDEBUG:
+		return pacta.AuditLogAction_DisableAdminDebug, nil
+	case api.AuditLogActionDOWNLOAD:
+		return pacta.AuditLogAction_Download, nil
+	case api.AuditLogActionENABLESHARING:
+		return pacta.AuditLogAction_EnableSharing, nil
+	case api.AuditLogActionDISABLESHARING:
+		return pacta.AuditLogAction_DisableSharing, nil
+	}
+	return "", oapierr.BadRequest("unknown audit log action", zap.String("audit_log_action", string(i)))
 }
 
 func auditLogActorTypeFromOAPI(i api.AuditLogActorType) (pacta.AuditLogActorType, error) {
-	return pacta.ParseAuditLogActorType(string(i))
+	switch i {
+	case api.AuditLogActorTypePUBLIC:
+		return pacta.AuditLogActorType_Public, nil
+	case api.AuditLogActorTypeOWNER:
+		return pacta.AuditLogActorType_Owner, nil
+	case api.AuditLogActorTypeADMIN:
+		return pacta.AuditLogActorType_Admin, nil
+	case api.AuditLogActorTypeSUPERADMIN:
+		return pacta.AuditLogActorType_SuperAdmin, nil
+	case api.AuditLogActorTypeSYSTEM:
+		return pacta.AuditLogActorType_System, nil
+	}
+	return "", oapierr.BadRequest("unknown audit log actor type", zap.String("audit_log_actor_type", string(i)))
 }
 
 func auditLogTargetTypeFromOAPI(i api.AuditLogTargetType) (pacta.AuditLogTargetType, error) {
-	return pacta.ParseAuditLogTargetType(string(i))
+	switch i {
+	case api.AuditLogTargetTypeUSER:
+		return pacta.AuditLogTargetType_User, nil
+	case api.AuditLogTargetTypePORTFOLIO:
+		return pacta.AuditLogTargetType_Portfolio, nil
+	case api.AuditLogTargetTypeINCOMPLETEUPLOAD:
+		return pacta.AuditLogTargetType_IncompleteUpload, nil
+	case api.AuditLogTargetTypePORTFOLIOGROUP:
+		return pacta.AuditLogTargetType_PortfolioGroup, nil
+	case api.AuditLogTargetTypeINITIATIVE:
+		return pacta.AuditLogTargetType_Initiative, nil
+	case api.AuditLogTargetTypePACTAVERSION:
+		return pacta.AuditLogTargetType_PACTAVersion, nil
+	case api.AuditLogTargetTypeANALYSIS:
+		return pacta.AuditLogTargetType_Analysis, nil
+	}
+	return "", oapierr.BadRequest("unknown audit log target type", zap.String("audit_log_target_type", string(i)))
 }
 
 func auditLogQueryWhereFromOAPI(i api.AuditLogQueryWhere) (*db.AuditLogQueryWhere, error) {
@@ -168,7 +232,29 @@ func auditLogQueryWhereFromOAPI(i api.AuditLogQueryWhere) (*db.AuditLogQueryWher
 }
 
 func auditLogQuerySortByFromOAPI(i api.AuditLogQuerySortBy) (db.AuditLogQuerySortBy, error) {
-	return db.ParseAuditLogQuerySortBy(string(i))
+	switch i {
+	case api.AuditLogQuerySortByCREATEDAT:
+		return db.AuditLogQuerySortBy_CreatedAt, nil
+	case api.AuditLogQuerySortByACTORTYPE:
+		return db.AuditLogQuerySortBy_ActorType, nil
+	case api.AuditLogQuerySortByACTORID:
+		return db.AuditLogQuerySortBy_ActorID, nil
+	case api.AuditLogQuerySortByACTOROWNERID:
+		return db.AuditLogQuerySortBy_ActorOwnerID, nil
+	case api.AuditLogQuerySortByPRIMARYTARGETID:
+		return db.AuditLogQuerySortBy_PrimaryTargetID, nil
+	case api.AuditLogQuerySortByPRIMARYTARGETTYPE:
+		return db.AuditLogQuerySortBy_PrimaryTargetType, nil
+	case api.AuditLogQuerySortByPRIMARYTARGETOWNERID:
+		return db.AuditLogQuerySortBy_PrimaryTargetOwnerID, nil
+	case api.AuditLogQuerySortBySECONDARYTARGETID:
+		return db.AuditLogQuerySortBy_SecondaryTargetID, nil
+	case api.AuditLogQuerySortBySECONDARYTARGETTYPE:
+		return db.AuditLogQuerySortBy_SecondaryTargetType, nil
+	case api.AuditLogQuerySortBySECONDARYTARGETOWNERID:
+		return db.AuditLogQuerySortBy_SecondaryTargetOwnerID, nil
+	}
+	return "", oapierr.BadRequest("unknown audit log query sort by", zap.String("audit_log_query_sort_by", string(i)))
 }
 
 func auditLogQuerySortFromOAPI(i api.AuditLogQuerySort) (*db.AuditLogQuerySort, error) {

--- a/cmd/server/pactasrv/conv/pacta_to_oapi.go
+++ b/cmd/server/pactasrv/conv/pacta_to_oapi.go
@@ -417,15 +417,15 @@ func AnalysesToOAPI(as []*pacta.Analysis) ([]*api.Analysis, error) {
 func auditLogActorTypeToOAPI(i pacta.AuditLogActorType) (api.AuditLogActorType, error) {
 	switch i {
 	case pacta.AuditLogActorType_Public:
-		return api.AuditLogActorTypePUBLIC, nil
+		return api.AuditLogActorTypePublic, nil
 	case pacta.AuditLogActorType_Owner:
-		return api.AuditLogActorTypeOWNER, nil
+		return api.AuditLogActorTypeOwner, nil
 	case pacta.AuditLogActorType_Admin:
-		return api.AuditLogActorTypeADMIN, nil
+		return api.AuditLogActorTypeAdmin, nil
 	case pacta.AuditLogActorType_SuperAdmin:
-		return api.AuditLogActorTypeSUPERADMIN, nil
+		return api.AuditLogActorTypeSuperAdmin, nil
 	case pacta.AuditLogActorType_System:
-		return api.AuditLogActorTypeSYSTEM, nil
+		return api.AuditLogActorTypeSystem, nil
 	}
 	return "", oapierr.Internal(fmt.Sprintf("auditLogActorTypeToOAPI: unknown actor type: %q", i))
 }
@@ -433,25 +433,25 @@ func auditLogActorTypeToOAPI(i pacta.AuditLogActorType) (api.AuditLogActorType, 
 func auditLogActionToOAPI(i pacta.AuditLogAction) (api.AuditLogAction, error) {
 	switch i {
 	case pacta.AuditLogAction_Create:
-		return api.AuditLogActionCREATE, nil
+		return api.AuditLogActionCreate, nil
 	case pacta.AuditLogAction_Update:
-		return api.AuditLogActionUPDATE, nil
+		return api.AuditLogActionUpdate, nil
 	case pacta.AuditLogAction_Delete:
-		return api.AuditLogActionDELETE, nil
+		return api.AuditLogActionDelete, nil
 	case pacta.AuditLogAction_AddTo:
-		return api.AuditLogActionADDTO, nil
+		return api.AuditLogActionAddTo, nil
 	case pacta.AuditLogAction_RemoveFrom:
-		return api.AuditLogActionREMOVEFROM, nil
+		return api.AuditLogActionRemoveFrom, nil
 	case pacta.AuditLogAction_EnableAdminDebug:
-		return api.AuditLogActionENABLEADMINDEBUG, nil
+		return api.AuditLogActionEnableAdminDebug, nil
 	case pacta.AuditLogAction_DisableAdminDebug:
-		return api.AuditLogActionDISABLEADMINDEBUG, nil
+		return api.AuditLogActionDisableAdminDebug, nil
 	case pacta.AuditLogAction_Download:
-		return api.AuditLogActionDOWNLOAD, nil
+		return api.AuditLogActionDownload, nil
 	case pacta.AuditLogAction_EnableSharing:
-		return api.AuditLogActionENABLESHARING, nil
+		return api.AuditLogActionEnableSharing, nil
 	case pacta.AuditLogAction_DisableSharing:
-		return api.AuditLogActionDISABLESHARING, nil
+		return api.AuditLogActionDisableSharing, nil
 	}
 	return "", oapierr.Internal(fmt.Sprintf("auditLogActionToOAPI: unknown action: %q", i))
 }
@@ -459,19 +459,19 @@ func auditLogActionToOAPI(i pacta.AuditLogAction) (api.AuditLogAction, error) {
 func auditLogTargetTypeToOAPI(i pacta.AuditLogTargetType) (api.AuditLogTargetType, error) {
 	switch i {
 	case pacta.AuditLogTargetType_User:
-		return api.AuditLogTargetTypeUSER, nil
+		return api.AuditLogTargetTypeUser, nil
 	case pacta.AuditLogTargetType_Portfolio:
-		return api.AuditLogTargetTypePORTFOLIO, nil
+		return api.AuditLogTargetTypePortfolio, nil
 	case pacta.AuditLogTargetType_IncompleteUpload:
-		return api.AuditLogTargetTypeINCOMPLETEUPLOAD, nil
+		return api.AuditLogTargetTypeIncompleteUpload, nil
 	case pacta.AuditLogTargetType_PortfolioGroup:
-		return api.AuditLogTargetTypePORTFOLIOGROUP, nil
+		return api.AuditLogTargetTypePortfolioGroup, nil
 	case pacta.AuditLogTargetType_Initiative:
-		return api.AuditLogTargetTypeINITIATIVE, nil
+		return api.AuditLogTargetTypeInitiative, nil
 	case pacta.AuditLogTargetType_PACTAVersion:
-		return api.AuditLogTargetTypePACTAVERSION, nil
+		return api.AuditLogTargetTypePactaVersion, nil
 	case pacta.AuditLogTargetType_Analysis:
-		return api.AuditLogTargetTypeANALYSIS, nil
+		return api.AuditLogTargetTypeAnalysis, nil
 	}
 	return "", oapierr.Internal(fmt.Sprintf("auditLogTargetTypeToOAPI: unknown target type: %q", i))
 }

--- a/cmd/server/pactasrv/initiative.go
+++ b/cmd/server/pactasrv/initiative.go
@@ -46,7 +46,7 @@ func (s *Server) UpdateInitiative(ctx context.Context, request api.UpdateInitiat
 		mutations = append(mutations, db.SetInitiativeIsAcceptingNewPortfolios(*b.IsAcceptingNewPortfolios))
 	}
 	if b.Language != nil {
-		lang, err := pacta.ParseLanguage(string(*b.Language))
+		lang, err := conv.LanguageFromOAPI(*b.Language)
 		if err != nil {
 			return nil, oapierr.BadRequest("failed to parse language", zap.Error(err))
 		}

--- a/cmd/server/pactasrv/user.go
+++ b/cmd/server/pactasrv/user.go
@@ -43,7 +43,7 @@ func (s *Server) UpdateUser(ctx context.Context, request api.UpdateUserRequestOb
 		mutations = append(mutations, db.SetUserName(*request.Body.Name))
 	}
 	if request.Body.PreferredLanguage != nil {
-		lang, err := pacta.ParseLanguage(string(*request.Body.PreferredLanguage))
+		lang, err := conv.LanguageFromOAPI(*request.Body.PreferredLanguage)
 		if err != nil {
 			return nil, oapierr.BadRequest("invalid language", zap.Error(err))
 		}

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -19,31 +19,7 @@ info:
     url: https://mit-license.org/
 servers:
   - url: TODO
-definitions:
-  Language:
-    type: string
-    enum: &LANGUAGES
-      - en
-      - fr
-      - es
-      - de
-  FileType:
-    type: string
-    enum: &FILE_TYPES
-      - csv
-      - yaml
-      - zip
-      - json 
-      - html 
-  AnalysisType:
-    type: string
-    enum: &ANALYSIS_TYPES
-      - audit 
-      - report
-  FailureCode:
-    type: string
-    enum: &FAILURE_CODES
-      - UNKNOWN
+
 basePath: /v1
 paths:
   /access-blob-content:
@@ -990,16 +966,28 @@ components:
   schemas:
     Language:
       type: string
-      enum: *LANGUAGES
+      enum:
+        - Language_EN
+        - Language_FR
+        - Language_ES
+        - Language_DE
     FileType:
       type: string
-      enum: *FILE_TYPES
+      enum:
+        - FileType_CSV
+        - FileType_YAML
+        - FileType_ZIP
+        - FileType_JSON
+        - FileType_HTML
     AnalysisType:
       type: string
-      enum: *ANALYSIS_TYPES
+      enum:
+        - AnalysisType_AUDIT
+        - AnalysisType_REPORT
     FailureCode:
       type: string
-      enum: *FAILURE_CODES
+      enum:
+        - FailureCode_UNKNOWN
     PactaVersionCreate:
       type: object
       required:

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -967,27 +967,27 @@ components:
     Language:
       type: string
       enum:
-        - Language_EN
-        - Language_FR
-        - Language_ES
-        - Language_DE
+        - LanguageEN
+        - LanguageFR
+        - LanguageES
+        - LanguageDE
     FileType:
       type: string
       enum:
-        - FileType_CSV
-        - FileType_YAML
-        - FileType_ZIP
-        - FileType_JSON
-        - FileType_HTML
+        - FileTypeCSV
+        - FileTypeYAML
+        - FileTypeZIP
+        - FileTypeJSON
+        - FileTypeHTML
     AnalysisType:
       type: string
       enum:
-        - AnalysisType_AUDIT
-        - AnalysisType_REPORT
+        - AnalysisTypeAUDIT
+        - AnalysisTypeREPORT
     FailureCode:
       type: string
       enum:
-        - FailureCode_UNKNOWN
+        - FailureCodeUNKNOWN
     PactaVersionCreate:
       type: object
       required:
@@ -1869,34 +1869,34 @@ components:
     AuditLogAction:
       type: string
       enum:
-        - AuditLogAction_CREATE
-        - AuditLogAction_UPDATE
-        - AuditLogAction_DELETE
-        - AuditLogAction_ADD_TO
-        - AuditLogAction_REMOVE_FROM
-        - AuditLogAction_ENABLE_ADMIN_DEBUG
-        - AuditLogAction_DISABLE_ADMIN_DEBUG
-        - AuditLogAction_DOWNLOAD
-        - AuditLogAction_ENABLE_SHARING
-        - AuditLogAction_DISABLE_SHARING
+        - AuditLogActionCreate
+        - AuditLogActionUpdate
+        - AuditLogActionDelete
+        - AuditLogActionAddTo
+        - AuditLogActionRemoveFrom
+        - AuditLogActionEnableAdminDebug
+        - AuditLogActionDisableAdminDebug
+        - AuditLogActionDownload
+        - AuditLogActionEnableSharing
+        - AuditLogActionDisableSharing
     AuditLogActorType:
       type: string
       enum:
-        - AuditLogActorType_PUBLIC
-        - AuditLogActorType_OWNER
-        - AuditLogActorType_ADMIN
-        - AuditLogActorType_SUPER_ADMIN
-        - AuditLogActorType_SYSTEM
+        - AuditLogActorTypePublic
+        - AuditLogActorTypeOwner
+        - AuditLogActorTypeAdmin
+        - AuditLogActorTypeSuperAdmin
+        - AuditLogActorTypeSystem
     AuditLogTargetType:
       type: string
       enum:
-        - AuditLogTargetType_USER
-        - AuditLogTargetType_PORTFOLIO
-        - AuditLogTargetType_INCOMPLETE_UPLOAD
-        - AuditLogTargetType_PORTFOLIO_GROUP
-        - AuditLogTargetType_INITIATIVE
-        - AuditLogTargetType_PACTA_VERSION
-        - AuditLogTargetType_ANALYSIS
+        - AuditLogTargetTypeUser
+        - AuditLogTargetTypePortfolio
+        - AuditLogTargetTypeIncompleteUpload
+        - AuditLogTargetTypePortfolioGroup
+        - AuditLogTargetTypeInitiative
+        - AuditLogTargetTypePactaVersion
+        - AuditLogTargetTypeAnalysis
     AuditLogQueryWhere:
       type: object
       properties:
@@ -1951,16 +1951,16 @@ components:
     AuditLogQuerySortBy:
       type: string
       enum:
-        - AuditLogQuerySortBy_CREATED_AT
-        - AuditLogQuerySortBy_ACTOR_TYPE
-        - AuditLogQuerySortBy_ACTOR_ID
-        - AuditLogQuerySortBy_ACTOR_OWNER_ID
-        - AuditLogQuerySortBy_PRIMARY_TARGET_ID
-        - AuditLogQuerySortBy_PRIMARY_TARGET_TYPE
-        - AuditLogQuerySortBy_PRIMARY_TARGET_OWNER_ID
-        - AuditLogQuerySortBy_SECONDARY_TARGET_ID
-        - AuditLogQuerySortBy_SECONDARY_TARGET_TYPE
-        - AuditLogQuerySortBy_SECONDARY_TARGET_OWNER_ID
+        - AuditLogQuerySortByCreatedAt
+        - AuditLogQuerySortByActorType
+        - AuditLogQuerySortByActorId
+        - AuditLogQuerySortByActorOwnerId
+        - AuditLogQuerySortByPrimaryTargetId
+        - AuditLogQuerySortByPrimaryTargetType
+        - AuditLogQuerySortByPrimaryTargetOwnerId
+        - AuditLogQuerySortBySecondaryTargetId
+        - AuditLogQuerySortBySecondaryTargetType
+        - AuditLogQuerySortBySecondaryTargetOwnerId
     AuditLogQuerySort:
       type: object
       required:


### PR DESCRIPTION
- Adds an enum prefix for every OpenAPI enum type, to avoid collisions + clean up the namespace (otherwise constants like `api.En` are generated).
- Removes use of YAML feature I hadn't understood prior (anchors + links), putting everything into the `schemas`, since `definitions` look like they're a Swagger (OAPI2.0) construct.
- Adds some basic Enum Round-Trip unit tests to pactasrv/conv
- removes usage of `pacta.ParseX` functions within the conv package, since these are less reliable than using the one for one, switch driven converters.