### PR TITLE
Creates Backend for Merging User Accounts

### DIFF
--- a/cmd/server/pactasrv/BUILD.bazel
+++ b/cmd/server/pactasrv/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "pactasrv",
     srcs = [
+        "admin.go",
         "analysis.go",
         "audit_logs.go",
         "blobs.go",

--- a/cmd/server/pactasrv/admin.go
+++ b/cmd/server/pactasrv/admin.go
@@ -1,0 +1,159 @@
+package pactasrv
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RMI/pacta/db"
+	"github.com/RMI/pacta/oapierr"
+	api "github.com/RMI/pacta/openapi/pacta"
+	"github.com/RMI/pacta/pacta"
+	"go.uber.org/zap"
+)
+
+// Merges two users together
+// (POST /admin/merge-users)
+func (s *Server) MergeUsers(ctx context.Context, request api.MergeUsersRequestObject) (api.MergeUsersResponseObject, error) {
+	req := request.Body
+	actorUserInfo, err := s.getActorInfoOrFail(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !actorUserInfo.IsAdmin && !actorUserInfo.IsSuperAdmin {
+		return nil, oapierr.Forbidden("only admins can merge users",
+			zap.String("actor_user_id", string(actorUserInfo.UserID)),
+			zap.String("from_user_id", req.FromUserId),
+			zap.String("to_user_id", req.ToUserId))
+	}
+
+	sourceUID := pacta.UserID(req.FromUserId)
+	destUID := pacta.UserID(req.ToUserId)
+
+	var (
+		numIncompleteUploads, numAnalyses, numPortfolios, numPortfolioGroups, numAuditLogs, numAuditLogsCreated int
+		buris                                                                                                   []pacta.BlobURI
+	)
+
+	err = s.DB.Transactional(ctx, func(tx db.Tx) error {
+		sourceOwner, err := s.DB.GetOwnerForUser(tx, sourceUID)
+		if err != nil {
+			return fmt.Errorf("failed to get owner for source user: %w", err)
+		}
+		destOwner, err := s.DB.GetOwnerForUser(tx, destUID)
+		if err != nil {
+			return fmt.Errorf("failed to get owner for destination user: %w", err)
+		}
+
+		// Note we do an audit log transfer FIRST so that we don't transfer the audit logs generated from the transfer itself.
+		nal, err := s.DB.TransferAuditLogOwnership(tx, sourceUID, destUID, sourceOwner, destOwner)
+		if err != nil {
+			return fmt.Errorf("failed to transfer audit log ownership: %w", err)
+		}
+		numAuditLogs = nal
+
+		auditLogsToCreate := []pacta.AuditLog{}
+		addAuditLog := func(t pacta.AuditLogTargetType, id string) {
+			auditLogsToCreate = append(auditLogsToCreate, pacta.AuditLog{
+				Action:               pacta.AuditLogAction_TransferOwnership,
+				ActorType:            pacta.AuditLogActorType_Admin,
+				ActorID:              string(actorUserInfo.UserID),
+				ActorOwner:           &pacta.Owner{ID: actorUserInfo.OwnerID},
+				PrimaryTargetType:    t,
+				PrimaryTargetID:      id,
+				PrimaryTargetOwner:   &pacta.Owner{ID: destOwner},
+				SecondaryTargetType:  pacta.AuditLogTargetType_User,
+				SecondaryTargetID:    string(sourceUID),
+				SecondaryTargetOwner: &pacta.Owner{ID: sourceOwner},
+			})
+		}
+
+		incompleteUploads, err := s.DB.IncompleteUploadsByOwner(tx, sourceOwner)
+		if err != nil {
+			return fmt.Errorf("failed to get incomplete uploads for source owner: %w", err)
+		}
+		for i, upload := range incompleteUploads {
+			err := s.DB.UpdateIncompleteUpload(tx, upload.ID, db.SetIncompleteUploadOwner(destOwner))
+			if err != nil {
+				return fmt.Errorf("failed to update upload owner %d/%d: %w", i, len(incompleteUploads), err)
+			}
+			addAuditLog(pacta.AuditLogTargetType_IncompleteUpload, string(upload.ID))
+		}
+		numIncompleteUploads = len(incompleteUploads)
+
+		analyses, err := s.DB.AnalysesByOwner(tx, sourceOwner)
+		if err != nil {
+			return fmt.Errorf("failed to get analyses for source owner: %w", err)
+		}
+		for i, analysis := range analyses {
+			err := s.DB.UpdateAnalysis(tx, analysis.ID, db.SetAnalysisOwner(destOwner))
+			if err != nil {
+				return fmt.Errorf("failed to update analysis owner %d/%d: %w", i, len(analyses), err)
+			}
+			addAuditLog(pacta.AuditLogTargetType_Analysis, string(analysis.ID))
+		}
+		numAnalyses = len(analyses)
+
+		portfolios, err := s.DB.PortfoliosByOwner(tx, sourceOwner)
+		if err != nil {
+			return fmt.Errorf("failed to get portfolios for source owner: %w", err)
+		}
+		for i, portfolio := range portfolios {
+			err := s.DB.UpdatePortfolio(tx, portfolio.ID, db.SetPortfolioOwner(destOwner))
+			if err != nil {
+				return fmt.Errorf("failed to update portfolio owner %d/%d: %w", i, len(portfolios), err)
+			}
+			addAuditLog(pacta.AuditLogTargetType_Portfolio, string(portfolio.ID))
+		}
+		numPortfolios = len(portfolios)
+
+		portfolioGroups, err := s.DB.PortfolioGroupsByOwner(tx, sourceOwner)
+		if err != nil {
+			return fmt.Errorf("failed to get portfolio groups for source owner: %w", err)
+		}
+		for i, portfolioGroup := range portfolioGroups {
+			err := s.DB.UpdatePortfolioGroup(tx, portfolioGroup.ID, db.SetPortfolioGroupOwner(destOwner))
+			if err != nil {
+				return fmt.Errorf("failed to update portfolio group owner %d/%d: %w", i, len(portfolioGroups), err)
+			}
+			addAuditLog(pacta.AuditLogTargetType_PortfolioGroup, string(portfolioGroup.ID))
+		}
+		numPortfolioGroups = len(portfolioGroups)
+
+		for _, auditLog := range auditLogsToCreate {
+			_, err := s.DB.CreateAuditLog(tx, &auditLog)
+			if err != nil {
+				return fmt.Errorf("failed to create audit log: %w", err)
+			}
+		}
+		numAuditLogsCreated = len(auditLogsToCreate)
+
+		// Now that we've transferred all the audit logs, we can delete the user.
+		newBuris, err := s.DB.DeleteUser(tx, sourceUID)
+		if err != nil {
+			return fmt.Errorf("failed to delete user: %w", err)
+		}
+		buris = append(buris, newBuris...)
+
+		return nil
+	})
+	if err != nil {
+		return nil, oapierr.Internal("failed to merge users", zap.Error(err), zap.String("actor_user_id", string(actorUserInfo.UserID)), zap.String("from_user_id", req.FromUserId), zap.String("to_user_id", req.ToUserId))
+	}
+
+	if err := s.deleteBlobs(ctx, buris...); err != nil {
+		return nil, err
+	}
+
+	s.Logger.Info("user merge completed successfully",
+		zap.String("actor_user_id", string(actorUserInfo.UserID)),
+		zap.String("from_user_id", req.FromUserId),
+		zap.String("to_user_id", req.ToUserId),
+		zap.Int("num_audit_logs_transferred", numAuditLogs),
+		zap.Int("num_incomplete_uploads", numIncompleteUploads),
+		zap.Int("num_analyses", numAnalyses),
+		zap.Int("num_portfolios", numPortfolios),
+		zap.Int("num_portfolio_groups", numPortfolioGroups),
+		zap.Int("num_audit_logs_created", numAuditLogsCreated),
+	)
+	return api.MergeUsers204Response{}, nil
+}

--- a/cmd/server/pactasrv/conv/oapi_to_pacta.go
+++ b/cmd/server/pactasrv/conv/oapi_to_pacta.go
@@ -144,6 +144,8 @@ func auditLogActionFromOAPI(i api.AuditLogAction) (pacta.AuditLogAction, error) 
 		return pacta.AuditLogAction_EnableSharing, nil
 	case api.AuditLogActionDisableSharing:
 		return pacta.AuditLogAction_DisableSharing, nil
+	case api.AuditLogActionTransferOwnership:
+		return pacta.AuditLogAction_TransferOwnership, nil
 	}
 	return "", oapierr.BadRequest("unknown audit log action", zap.String("audit_log_action", string(i)))
 }

--- a/cmd/server/pactasrv/conv/pacta_to_oapi.go
+++ b/cmd/server/pactasrv/conv/pacta_to_oapi.go
@@ -452,6 +452,8 @@ func auditLogActionToOAPI(i pacta.AuditLogAction) (api.AuditLogAction, error) {
 		return api.AuditLogActionEnableSharing, nil
 	case pacta.AuditLogAction_DisableSharing:
 		return api.AuditLogActionDisableSharing, nil
+	case pacta.AuditLogAction_TransferOwnership:
+		return api.AuditLogActionTransferOwnership, nil
 	}
 	return "", oapierr.Internal(fmt.Sprintf("auditLogActionToOAPI: unknown action: %q", i))
 }

--- a/cmd/server/pactasrv/pactasrv.go
+++ b/cmd/server/pactasrv/pactasrv.go
@@ -117,8 +117,11 @@ type DB interface {
 	DeleteUser(tx db.Tx, id pacta.UserID) ([]pacta.BlobURI, error)
 
 	CreateAuditLog(tx db.Tx, a *pacta.AuditLog) (pacta.AuditLogID, error)
+	CreateAuditLogs(tx db.Tx, as []*pacta.AuditLog) error
 	AuditLogs(tx db.Tx, q *db.AuditLogQuery) ([]*pacta.AuditLog, *db.PageInfo, error)
-	TransferAuditLogOwnership(tx db.Tx, sourceUserID, destUserID pacta.UserID, sourceOwnerID, destOwnerID pacta.OwnerID) (int, error)
+
+	RecordUserMerge(tx db.Tx, fromUserID, toUserID, actorUserID pacta.UserID) error
+	RecordOwnerMerge(tx db.Tx, fromUserID, toUserID pacta.OwnerID, actorUserID pacta.UserID) error
 }
 
 type Blob interface {
@@ -212,7 +215,7 @@ type actorInfo struct {
 	IsSuperAdmin bool
 }
 
-func (s *Server) getActorInfoOrFail(ctx context.Context) (*actorInfo, error) {
+func (s *Server) getactorInfoOrErrIfAnon(ctx context.Context) (*actorInfo, error) {
 	actorUserID, err := getUserID(ctx)
 	if err != nil {
 		return nil, err

--- a/cmd/server/pactasrv/pactasrv.go
+++ b/cmd/server/pactasrv/pactasrv.go
@@ -114,10 +114,11 @@ type DB interface {
 	User(tx db.Tx, id pacta.UserID) (*pacta.User, error)
 	Users(tx db.Tx, ids []pacta.UserID) (map[pacta.UserID]*pacta.User, error)
 	UpdateUser(tx db.Tx, id pacta.UserID, mutations ...db.UpdateUserFn) error
-	DeleteUser(tx db.Tx, id pacta.UserID) error
+	DeleteUser(tx db.Tx, id pacta.UserID) ([]pacta.BlobURI, error)
 
 	CreateAuditLog(tx db.Tx, a *pacta.AuditLog) (pacta.AuditLogID, error)
 	AuditLogs(tx db.Tx, q *db.AuditLogQuery) ([]*pacta.AuditLog, *db.PageInfo, error)
+	TransferAuditLogOwnership(tx db.Tx, sourceUserID, destUserID pacta.UserID, sourceOwnerID, destOwnerID pacta.OwnerID) (int, error)
 }
 
 type Blob interface {

--- a/cmd/server/pactasrv/user.go
+++ b/cmd/server/pactasrv/user.go
@@ -60,9 +60,12 @@ func (s *Server) UpdateUser(ctx context.Context, request api.UpdateUserRequestOb
 // (DELETE /user/{id})
 func (s *Server) DeleteUser(ctx context.Context, request api.DeleteUserRequestObject) (api.DeleteUserResponseObject, error) {
 	// TODO(#12) Implement Authorization
-	err := s.DB.DeleteUser(s.DB.NoTxn(ctx), pacta.UserID(request.Id))
+	blobURIs, err := s.DB.DeleteUser(s.DB.NoTxn(ctx), pacta.UserID(request.Id))
 	if err != nil {
 		return nil, oapierr.Internal("failed to delete user", zap.Error(err))
+	}
+	if err := s.deleteBlobs(ctx, blobURIs...); err != nil {
+		return nil, err
 	}
 	return api.DeleteUser204Response{}, nil
 }

--- a/db/sqldb/BUILD.bazel
+++ b/db/sqldb/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "initiative_invitation_test.go",
         "initiative_test.go",
         "initiative_user_test.go",
+        "merge_test.go",
         "owner_test.go",
         "pacta_version_test.go",
         "portfolio_group_test.go",

--- a/db/sqldb/BUILD.bazel
+++ b/db/sqldb/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "initiative.go",
         "initiative_invitation.go",
         "initiative_user.go",
+        "merge.go",
         "owner.go",
         "pacta_version.go",
         "portfolio.go",

--- a/db/sqldb/golden/human_readable_schema.sql
+++ b/db/sqldb/golden/human_readable_schema.sql
@@ -176,6 +176,13 @@ ALTER TABLE ONLY owner ADD CONSTRAINT owner_initiative_id_fkey FOREIGN KEY (init
 ALTER TABLE ONLY owner ADD CONSTRAINT owner_user_id_fkey FOREIGN KEY (user_id) REFERENCES pacta_user(id) ON DELETE RESTRICT;
 
 
+CREATE TABLE owner_merges (
+	actor_user_id text NOT NULL,
+	from_owner_id text NOT NULL,
+	merged_at timestamp with time zone DEFAULT now() NOT NULL,
+	to_owner_id text NOT NULL);
+
+
 CREATE TABLE pacta_user (
 	admin boolean NOT NULL,
 	authn_id text NOT NULL,
@@ -270,4 +277,11 @@ CREATE TABLE schema_migrations_history (
 	id integer NOT NULL,
 	version bigint NOT NULL);
 ALTER SEQUENCE schema_migrations_history_id_seq OWNED BY schema_migrations_history.id;
+
+
+CREATE TABLE user_merges (
+	actor_user_id text NOT NULL,
+	from_user_id text NOT NULL,
+	merged_at timestamp with time zone DEFAULT now() NOT NULL,
+	to_user_id text NOT NULL);
 ALTER TABLE ONLY schema_migrations ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);

--- a/db/sqldb/golden/human_readable_schema.sql
+++ b/db/sqldb/golden/human_readable_schema.sql
@@ -18,7 +18,8 @@ CREATE TYPE audit_log_action AS ENUM (
     'DISABLE_ADMIN_DEBUG',
     'DOWNLOAD',
     'ENABLE_SHARING',
-    'DISABLE_SHARING');
+    'DISABLE_SHARING',
+    'TRANSFER_OWNERSHIP');
 CREATE TYPE audit_log_actor_type AS ENUM (
     'USER',
     'ADMIN',

--- a/db/sqldb/golden/schema_dump.sql
+++ b/db/sqldb/golden/schema_dump.sql
@@ -42,7 +42,8 @@ CREATE TYPE public.audit_log_action AS ENUM (
     'DISABLE_ADMIN_DEBUG',
     'DOWNLOAD',
     'ENABLE_SHARING',
-    'DISABLE_SHARING'
+    'DISABLE_SHARING',
+    'TRANSFER_OWNERSHIP'
 );
 
 

--- a/db/sqldb/golden/schema_dump.sql
+++ b/db/sqldb/golden/schema_dump.sql
@@ -319,6 +319,20 @@ CREATE TABLE public.owner (
 ALTER TABLE public.owner OWNER TO postgres;
 
 --
+-- Name: owner_merges; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.owner_merges (
+    from_owner_id text NOT NULL,
+    to_owner_id text NOT NULL,
+    actor_user_id text NOT NULL,
+    merged_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.owner_merges OWNER TO postgres;
+
+--
 -- Name: pacta_user; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -478,6 +492,20 @@ ALTER TABLE public.schema_migrations_history_id_seq OWNER TO postgres;
 
 ALTER SEQUENCE public.schema_migrations_history_id_seq OWNED BY public.schema_migrations_history.id;
 
+
+--
+-- Name: user_merges; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_merges (
+    from_user_id text NOT NULL,
+    to_user_id text NOT NULL,
+    actor_user_id text NOT NULL,
+    merged_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.user_merges OWNER TO postgres;
 
 --
 -- Name: schema_migrations_history id; Type: DEFAULT; Schema: public; Owner: postgres

--- a/db/sqldb/merge.go
+++ b/db/sqldb/merge.go
@@ -1,0 +1,128 @@
+package sqldb
+
+import (
+	"fmt"
+
+	"github.com/RMI/pacta/db"
+	"github.com/RMI/pacta/pacta"
+)
+
+func (d *DB) RecordUserMerge(tx db.Tx, fromUserID, toUserID, actorUserID pacta.UserID) error {
+	err := d.exec(tx, `
+		INSERT INTO user_merges 
+			(from_user_id, to_user_id, actor_user_id)
+			VALUES ($1, $2, $3);`, fromUserID, toUserID, actorUserID)
+	if err != nil {
+		return fmt.Errorf("inserting user merge: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) RecordOwnerMerge(tx db.Tx, fromOwnerID, toOwnerID pacta.OwnerID, actorUserID pacta.UserID) error {
+	err := d.exec(tx, `
+		INSERT INTO owner_merges 
+			(from_owner_id, to_owner_id, actor_user_id)
+			VALUES ($1, $2, $3);`, fromOwnerID, toOwnerID, actorUserID)
+	if err != nil {
+		return fmt.Errorf("inserting owner merge: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) expandAuditLogQueryToAccountForMerges(tx db.Tx, q *db.AuditLogQuery) (*db.AuditLogQuery, error) {
+	var err error
+	for _, w := range q.Wheres {
+		w.InActorID, err = d.findAllMergedUsers(tx, w.InActorID)
+		if err != nil {
+			return nil, fmt.Errorf("finding merged users for actor_id: %w", err)
+		}
+
+		w.InTargetID, err = d.findAllMergedUsers(tx, w.InTargetID)
+		if err != nil {
+			return nil, fmt.Errorf("finding merged users for target_id: %w", err)
+		}
+
+		w.InActorOwnerID, err = d.findAllMergedOwners(tx, w.InActorOwnerID)
+		if err != nil {
+			return nil, fmt.Errorf("finding merged owners for actor_owner_id: %w", err)
+		}
+
+		w.InTargetOwnerID, err = d.findAllMergedOwners(tx, w.InTargetOwnerID)
+		if err != nil {
+			return nil, fmt.Errorf("finding merged owners for actor_owner_id: %w", err)
+		}
+	}
+	return q, nil
+}
+
+func (d *DB) findAllMergedOwners(tx db.Tx, in []pacta.OwnerID) ([]pacta.OwnerID, error) {
+	relationshipFn := func(id pacta.OwnerID) ([]pacta.OwnerID, error) {
+		return d.findMergedOwners(tx, pacta.OwnerID(id))
+	}
+	return recursivelyExpandRelationships(in, relationshipFn)
+}
+
+func (d *DB) findMergedOwners(tx db.Tx, id pacta.OwnerID) ([]pacta.OwnerID, error) {
+	rows, err := d.query(tx, `
+		(SELECT from_owner_id FROM owner_merges WHERE to_owner_id = $1)
+		UNION
+		(SELECT to_owner_id FROM owner_merges WHERE from_owner_id = $1);`, id)
+	if err != nil {
+		return nil, fmt.Errorf("querying owner_merges: %w", err)
+	}
+	ownerIDs, err := mapRowsToIDs[pacta.OwnerID]("merged_owners", rows)
+	if err != nil {
+		return nil, fmt.Errorf("mapping rows to owner ids: %w", err)
+	}
+	return ownerIDs, nil
+}
+
+func (d *DB) findAllMergedUsers(tx db.Tx, in []string) ([]string, error) {
+	relationshipFn := func(id string) ([]string, error) {
+		others, err := d.findMergedUsers(tx, pacta.UserID(id))
+		if err != nil {
+			return nil, fmt.Errorf("finding merged users for %q: %w", id, err)
+		}
+		return asStrs(others), nil
+	}
+	return recursivelyExpandRelationships(in, relationshipFn)
+}
+
+func (d *DB) findMergedUsers(tx db.Tx, id pacta.UserID) ([]pacta.UserID, error) {
+	rows, err := d.query(tx, `
+		(SELECT from_user_id FROM user_merges WHERE to_user_id = $1)
+		UNION
+		(SELECT to_user_id FROM user_merges WHERE from_user_id = $1);`, id)
+	if err != nil {
+		return nil, fmt.Errorf("querying user_merges: %w", err)
+	}
+	userIDs, err := mapRowsToIDs[pacta.UserID]("merged_users", rows)
+	if err != nil {
+		return nil, fmt.Errorf("mapping rows to user ids: %w", err)
+	}
+	return userIDs, nil
+}
+
+func recursivelyExpandRelationships[S ~string](in []S, relatedFn func(S) ([]S, error)) ([]S, error) {
+	if len(in) == 0 {
+		return in, nil
+	}
+	all := asSet(in)
+	lookedUp := map[S]bool{}
+	for len(lookedUp) < len(all) {
+		for s := range all {
+			if lookedUp[s] {
+				continue
+			}
+			related, err := relatedFn(s)
+			if err != nil {
+				return nil, fmt.Errorf("finding relationships for %q: %w", s, err)
+			}
+			for _, r := range related {
+				all[r] = true
+			}
+			lookedUp[s] = true
+		}
+	}
+	return keys(all), nil
+}

--- a/db/sqldb/merge_test.go
+++ b/db/sqldb/merge_test.go
@@ -1,0 +1,335 @@
+package sqldb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/RMI/pacta/pacta"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestMergeUsers(t *testing.T) {
+	ctx := context.Background()
+	tdb := createDBForTesting(t)
+	tx := tdb.NoTxn(ctx)
+	a := userForTestingWithKey(t, tdb, "A")
+	b := userForTestingWithKey(t, tdb, "B")
+	c := userForTestingWithKey(t, tdb, "C")
+	d := userForTestingWithKey(t, tdb, "D")
+	e := userForTestingWithKey(t, tdb, "E")
+	f := userForTestingWithKey(t, tdb, "F")
+
+	usersToIDs := func(users []*pacta.User) []string {
+		ids := []string{}
+		for _, u := range users {
+			ids = append(ids, string(u.ID))
+		}
+		return ids
+	}
+	cmpOpts := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+	runTests := func(name string, tests []struct {
+		in       []*pacta.User
+		expected []*pacta.User
+	}) {
+		t.Helper()
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s_case_%v", name, test.in), func(t *testing.T) {
+				got, err := tdb.findAllMergedUsers(tx, usersToIDs(test.in))
+				if err != nil {
+					t.Fatalf("get users: %v", err)
+				}
+				if diff := cmp.Diff(usersToIDs(test.expected), got, cmpOpts); diff != "" {
+					t.Fatalf("users mismatch (-want +got):\n%s", diff)
+				}
+			})
+
+		}
+	}
+
+	runTests("Pre-Merge", []struct {
+		in       []*pacta.User
+		expected []*pacta.User
+	}{
+		{
+			in:       []*pacta.User{},
+			expected: []*pacta.User{},
+		}, {
+			in:       []*pacta.User{a},
+			expected: []*pacta.User{a},
+		}, {
+			in:       []*pacta.User{c, c, c},
+			expected: []*pacta.User{c},
+		}, {
+			in:       []*pacta.User{e},
+			expected: []*pacta.User{e},
+		}, {
+			in:       []*pacta.User{a, b},
+			expected: []*pacta.User{a, b},
+		}, {
+			in:       []*pacta.User{a, b, c, d, e, f},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		},
+	})
+
+	// Merge A and B
+	if err := tdb.RecordUserMerge(tx, a.ID, b.ID, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+	// Merge C and D
+	if err := tdb.RecordUserMerge(tx, c.ID, d.ID, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+
+	runTests("Post-First-Merge", []struct {
+		in       []*pacta.User
+		expected []*pacta.User
+	}{
+		{
+			in:       []*pacta.User{},
+			expected: []*pacta.User{},
+		}, {
+			in:       []*pacta.User{a},
+			expected: []*pacta.User{a, b},
+		}, {
+			in:       []*pacta.User{e},
+			expected: []*pacta.User{e},
+		}, {
+			in:       []*pacta.User{c, c, c},
+			expected: []*pacta.User{c, d},
+		}, {
+			in:       []*pacta.User{a, b},
+			expected: []*pacta.User{a, b},
+		}, {
+			in:       []*pacta.User{a, b, c, d, e, f},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		},
+	})
+
+	// Merge B and E
+	if err := tdb.RecordUserMerge(tx, b.ID, e.ID, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+	// Merge B and F
+	if err := tdb.RecordUserMerge(tx, f.ID, b.ID, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+
+	runTests("Post-Second-Merge", []struct {
+		in       []*pacta.User
+		expected []*pacta.User
+	}{
+		{
+			in:       []*pacta.User{},
+			expected: []*pacta.User{},
+		}, {
+			in:       []*pacta.User{a},
+			expected: []*pacta.User{a, b, e, f},
+		}, {
+			in:       []*pacta.User{e},
+			expected: []*pacta.User{a, b, e, f},
+		}, {
+			in:       []*pacta.User{c, c, c},
+			expected: []*pacta.User{c, d},
+		}, {
+			in:       []*pacta.User{a, b},
+			expected: []*pacta.User{a, b, e, f},
+		}, {
+			in:       []*pacta.User{a, b, c, d, e, f},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		},
+	})
+
+	// Merge D and E
+	if err := tdb.RecordUserMerge(tx, d.ID, e.ID, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+
+	runTests("Post-Third-Merge", []struct {
+		in       []*pacta.User
+		expected []*pacta.User
+	}{
+		{
+			in:       []*pacta.User{},
+			expected: []*pacta.User{},
+		}, {
+			in:       []*pacta.User{a},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		}, {
+			in:       []*pacta.User{e},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		}, {
+			in:       []*pacta.User{c, c, c},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		}, {
+			in:       []*pacta.User{a, b},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		}, {
+			in:       []*pacta.User{a, b, c, d, e, f},
+			expected: []*pacta.User{a, b, c, d, e, f},
+		},
+	})
+}
+
+func TestMergeOwners(t *testing.T) {
+	ctx := context.Background()
+	tdb := createDBForTesting(t)
+	tx := tdb.NoTxn(ctx)
+	uA := userForTestingWithKey(t, tdb, "A")
+	uB := userForTestingWithKey(t, tdb, "B")
+	uC := userForTestingWithKey(t, tdb, "C")
+	uD := userForTestingWithKey(t, tdb, "D")
+	uE := userForTestingWithKey(t, tdb, "E")
+	uF := userForTestingWithKey(t, tdb, "F")
+	a, err0 := tdb.GetOwnerForUser(tx, uA.ID)
+	b, err1 := tdb.GetOwnerForUser(tx, uB.ID)
+	c, err2 := tdb.GetOwnerForUser(tx, uC.ID)
+	d, err3 := tdb.GetOwnerForUser(tx, uD.ID)
+	e, err4 := tdb.GetOwnerForUser(tx, uE.ID)
+	f, err5 := tdb.GetOwnerForUser(tx, uF.ID)
+	noErrDuringSetup(t, err0, err1, err2, err3, err4, err5)
+
+	cmpOpts := cmpopts.SortSlices(func(a, b pacta.OwnerID) bool { return a < b })
+	runTests := func(name string, tests []struct {
+		in       []pacta.OwnerID
+		expected []pacta.OwnerID
+	}) {
+		t.Helper()
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s_case_%v", name, test.in), func(t *testing.T) {
+				got, err := tdb.findAllMergedOwners(tx, test.in)
+				if err != nil {
+					t.Fatalf("get owners: %v", err)
+				}
+				if diff := cmp.Diff(test.expected, got, cmpOpts); diff != "" {
+					t.Fatalf("owners mismatch (-want +got):\n%s", diff)
+				}
+			})
+
+		}
+	}
+
+	runTests("Pre-Merge", []struct {
+		in       []pacta.OwnerID
+		expected []pacta.OwnerID
+	}{
+		{
+			in:       []pacta.OwnerID{},
+			expected: []pacta.OwnerID{},
+		}, {
+			in:       []pacta.OwnerID{a},
+			expected: []pacta.OwnerID{a},
+		}, {
+			in:       []pacta.OwnerID{c, c, c},
+			expected: []pacta.OwnerID{c},
+		}, {
+			in:       []pacta.OwnerID{e},
+			expected: []pacta.OwnerID{e},
+		}, {
+			in:       []pacta.OwnerID{a, b},
+			expected: []pacta.OwnerID{a, b},
+		}, {
+			in:       []pacta.OwnerID{a, b, c, d, e, f},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		},
+	})
+
+	// Merge A and B
+	if err := tdb.RecordOwnerMerge(tx, a, b, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+	// Merge C and D
+	if err := tdb.RecordOwnerMerge(tx, c, d, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+
+	runTests("Post-First-Merge", []struct {
+		in       []pacta.OwnerID
+		expected []pacta.OwnerID
+	}{
+		{
+			in:       []pacta.OwnerID{},
+			expected: []pacta.OwnerID{},
+		}, {
+			in:       []pacta.OwnerID{a},
+			expected: []pacta.OwnerID{a, b},
+		}, {
+			in:       []pacta.OwnerID{e},
+			expected: []pacta.OwnerID{e},
+		}, {
+			in:       []pacta.OwnerID{c, c, c},
+			expected: []pacta.OwnerID{c, d},
+		}, {
+			in:       []pacta.OwnerID{a, b},
+			expected: []pacta.OwnerID{a, b},
+		}, {
+			in:       []pacta.OwnerID{a, b, c, d, e, f},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		},
+	})
+
+	// Merge B and E
+	if err := tdb.RecordOwnerMerge(tx, b, e, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+	// Merge B and F
+	if err := tdb.RecordOwnerMerge(tx, f, b, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+
+	runTests("Post-Second-Merge", []struct {
+		in       []pacta.OwnerID
+		expected []pacta.OwnerID
+	}{
+		{
+			in:       []pacta.OwnerID{},
+			expected: []pacta.OwnerID{},
+		}, {
+			in:       []pacta.OwnerID{a},
+			expected: []pacta.OwnerID{a, b, e, f},
+		}, {
+			in:       []pacta.OwnerID{e},
+			expected: []pacta.OwnerID{a, b, e, f},
+		}, {
+			in:       []pacta.OwnerID{c, c, c},
+			expected: []pacta.OwnerID{c, d},
+		}, {
+			in:       []pacta.OwnerID{a, b},
+			expected: []pacta.OwnerID{a, b, e, f},
+		}, {
+			in:       []pacta.OwnerID{a, b, c, d, e, f},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		},
+	})
+
+	// Merge D and E
+	if err := tdb.RecordOwnerMerge(tx, d, e, "AdminID"); err != nil {
+		t.Fatalf("record merge: %v", err)
+	}
+
+	runTests("Post-Third-Merge", []struct {
+		in       []pacta.OwnerID
+		expected []pacta.OwnerID
+	}{
+		{
+			in:       []pacta.OwnerID{},
+			expected: []pacta.OwnerID{},
+		}, {
+			in:       []pacta.OwnerID{a},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		}, {
+			in:       []pacta.OwnerID{e},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		}, {
+			in:       []pacta.OwnerID{c, c, c},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		}, {
+			in:       []pacta.OwnerID{a, b},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		}, {
+			in:       []pacta.OwnerID{a, b, c, d, e, f},
+			expected: []pacta.OwnerID{a, b, c, d, e, f},
+		},
+	})
+}

--- a/db/sqldb/migrations/0009_add_transfer_audit_log_action.down.sql
+++ b/db/sqldb/migrations/0009_add_transfer_audit_log_action.down.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- There isn't a way to delete a value from an enum, so this is the workaround
+-- https://stackoverflow.com/a/56777227/17909149
+
+ALTER TABLE audit_log ALTER action TYPE TEXT;
+
+DROP TYPE audit_log_action;
+CREATE TYPE audit_log_action AS ENUM (
+    'CREATE',
+    'UPDATE',
+    'DELETE',
+    'ADD_TO',
+    'REMOVE_FROM',
+    'ENABLE_ADMIN_DEBUG',
+    'DISABLE_ADMIN_DEBUG',
+    'DOWNLOAD',
+    'ENABLE_SHARING',
+    'DISABLE_SHARING');
+
+ALTER TABLE audit_log 
+    ALTER action TYPE audit_log_action 
+        USING audit_log_action::audit_log_action;
+
+COMMIT;

--- a/db/sqldb/migrations/0009_add_transfer_audit_log_action.up.sql
+++ b/db/sqldb/migrations/0009_add_transfer_audit_log_action.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TYPE audit_log_action ADD VALUE 'TRANSFER_OWNERSHIP'; 
+
+COMMIT;

--- a/db/sqldb/migrations/0009_add_transfer_audit_log_action.up.sql
+++ b/db/sqldb/migrations/0009_add_transfer_audit_log_action.up.sql
@@ -1,5 +1,0 @@
-BEGIN;
-
-ALTER TYPE audit_log_action ADD VALUE 'TRANSFER_OWNERSHIP'; 
-
-COMMIT;

--- a/db/sqldb/migrations/0009_support_user_merge.down.sql
+++ b/db/sqldb/migrations/0009_support_user_merge.down.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+DROP TABLE owner_merges;
+DROP TABLE user_merges;
+
 -- There isn't a way to delete a value from an enum, so this is the workaround
 -- https://stackoverflow.com/a/56777227/17909149
 

--- a/db/sqldb/migrations/0009_support_user_merge.up.sql
+++ b/db/sqldb/migrations/0009_support_user_merge.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+ALTER TYPE audit_log_action ADD VALUE 'TRANSFER_OWNERSHIP'; 
+
+CREATE TABLE user_merges (
+    from_user_id TEXT NOT NULL,
+    to_user_id TEXT NOT NULL,
+    actor_user_id TEXT NOT NULL,
+    merged_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE owner_merges (
+    from_owner_id TEXT NOT NULL,
+    to_owner_id TEXT NOT NULL,
+    actor_user_id TEXT NOT NULL,
+    merged_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+COMMIT;

--- a/db/sqldb/owner.go
+++ b/db/sqldb/owner.go
@@ -112,6 +112,64 @@ func (d *DB) GetOrCreateOwnerForInitiative(tx db.Tx, iID pacta.InitiativeID) (pa
 	return ownerID, nil
 }
 
+func (d *DB) DeleteOwner(tx db.Tx, oID pacta.OwnerID) ([]pacta.BlobURI, error) {
+	var buris []pacta.BlobURI
+	err := d.RunOrContinueTransaction(tx, func(tx db.Tx) error {
+		portfolios, err := d.PortfoliosByOwner(tx, oID)
+		if err != nil {
+			return fmt.Errorf("getting portfolios for owner: %w", err)
+		}
+		for _, portfolio := range portfolios {
+			newBuris, err := d.DeletePortfolio(tx, portfolio.ID)
+			if err != nil {
+				return fmt.Errorf("deleting portfolio: %w", err)
+			}
+			buris = append(buris, newBuris...)
+		}
+		analyses, err := d.AnalysesByOwner(tx, oID)
+		if err != nil {
+			return fmt.Errorf("getting analyses for owner: %w", err)
+		}
+		for _, analysis := range analyses {
+			newBuris, err := d.DeleteAnalysis(tx, analysis.ID)
+			if err != nil {
+				return fmt.Errorf("deleting analysis: %w", err)
+			}
+			buris = append(buris, newBuris...)
+		}
+		pgroups, err := d.PortfolioGroupsByOwner(tx, oID)
+		if err != nil {
+			return fmt.Errorf("getting portfolio groups for owner: %w", err)
+		}
+		for _, pgroup := range pgroups {
+			err := d.DeletePortfolioGroup(tx, pgroup.ID)
+			if err != nil {
+				return fmt.Errorf("deleting portfolio group: %w", err)
+			}
+		}
+		incompleteUploads, err := d.IncompleteUploadsByOwner(tx, oID)
+		if err != nil {
+			return fmt.Errorf("getting incomplete uploads for owner: %w", err)
+		}
+		for _, iu := range incompleteUploads {
+			newBuri, err := d.DeleteIncompleteUpload(tx, iu.ID)
+			if err != nil {
+				return fmt.Errorf("deleting incomplete upload: %w", err)
+			}
+			buris = append(buris, newBuri)
+		}
+		err = d.exec(tx, `DELETE FROM owner WHERE id = $1;`, oID)
+		if err != nil {
+			return fmt.Errorf("deleting actual owner: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("deleting owner: %w", err)
+	}
+	return buris, nil
+}
+
 func (d *DB) createOwner(tx db.Tx, o *pacta.Owner) (pacta.OwnerID, error) {
 	if err := validateOwnerForCreation(o); err != nil {
 		return "", fmt.Errorf("validating owner for creation: %w", err)
@@ -183,5 +241,3 @@ func validateOwnerForCreation(o *pacta.Owner) error {
 	}
 	return nil
 }
-
-// TODO(grady) take on owner deletion

--- a/db/sqldb/sqldb_test.go
+++ b/db/sqldb/sqldb_test.go
@@ -90,6 +90,7 @@ func TestSchemaHistory(t *testing.T) {
 		{ID: 6, Version: 6}, // 0006_initiative_primary_key
 		{ID: 7, Version: 7}, // 0007_audit_log_actor_type
 		{ID: 8, Version: 8}, // 0008_indexes_on_blob_ids
+		{ID: 9, Version: 9}, // 0009_add_transfer_audit_log_action
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/db/sqldb/sqldb_test.go
+++ b/db/sqldb/sqldb_test.go
@@ -90,7 +90,7 @@ func TestSchemaHistory(t *testing.T) {
 		{ID: 6, Version: 6}, // 0006_initiative_primary_key
 		{ID: 7, Version: 7}, // 0007_audit_log_actor_type
 		{ID: 8, Version: 8}, // 0008_indexes_on_blob_ids
-		{ID: 9, Version: 9}, // 0009_add_transfer_audit_log_action
+		{ID: 9, Version: 9}, // 0009_support_user_merge
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/db/sqldb/user_test.go
+++ b/db/sqldb/user_test.go
@@ -218,7 +218,7 @@ func TestDeleteUser(t *testing.T) {
 	userID, err0 := tdb.createUser(tx, u)
 	noErrDuringSetup(t, err0)
 
-	err := tdb.DeleteUser(tx, userID)
+	_, err := tdb.DeleteUser(tx, userID)
 	if err != nil {
 		t.Fatalf("deleting user: %v", err)
 	}

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -147,10 +147,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MergeUsersRequest'
+              $ref: '#/components/schemas/MergeUsersReq'
       responses:
-        '204':
-          description: the user changes were applied successfully
+        '200':
+          description: the users were merged successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeUsersResp'
   /initiative/{id}:
     get:
       summary: Returns an initiative by ID
@@ -2074,7 +2078,7 @@ components:
         secondaryTargetOwner:
           type: string
           description: the id of the owner of the secondary object this action was performed on
-    MergeUsersRequest:
+    MergeUsersReq:
       type: object
       required:
         - fromUserId
@@ -2086,6 +2090,30 @@ components:
         toUserId:
           type: string
           description: the user id of the user to recieve merged records and to exist after the merge 
+    MergeUsersResp:
+      type: object
+      required:
+        - incompleteUploadCount
+        - analysisCount
+        - portfolioCount
+        - portfolioGroupCount
+        - auditLogsCreated
+      properties:
+        incompleteUploadCount:
+          type: integer
+          description: the number of incomplete uploads that were transferred to the new user 
+        analysisCount:
+          type: integer
+          description: the number of analyses that were transferred to the new user
+        portfolioCount:
+          type: integer
+          description: the number of portfolios that were transferred to the new user
+        portfolioGroupCount:
+          type: integer
+          description: the number of portfolio groups that were transferred to the new user
+        auditLogsCreated:
+          type: integer
+          description: the number of audit logs that were created to record the merge
     Error:
       type: object
       required:

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -136,6 +136,21 @@ paths:
       responses:
         '204':
           description: pacta version created successfully
+  /admin/merge-users:
+    post:
+      summary: Merges two users together
+      description: Merges two users together
+      operationId: mergeUsers
+      requestBody:
+        description: a request describing the two users to merge 
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MergeUsersRequest'
+      responses:
+        '204':
+          description: the user changes were applied successfully
   /initiative/{id}:
     get:
       summary: Returns an initiative by ID
@@ -1879,6 +1894,7 @@ components:
         - AuditLogActionDownload
         - AuditLogActionEnableSharing
         - AuditLogActionDisableSharing
+        - AuditLogActionTransferOwnership
     AuditLogActorType:
       type: string
       enum:
@@ -2058,6 +2074,18 @@ components:
         secondaryTargetOwner:
           type: string
           description: the id of the owner of the secondary object this action was performed on
+    MergeUsersRequest:
+      type: object
+      required:
+        - fromUserId
+        - toUserId
+      properties:
+        fromUserId:
+          type: string
+          description: the user id of the user to merge records from, and to be deleted after the merge 
+        toUserId:
+          type: string
+          description: the user id of the user to recieve merged records and to exist after the merge 
     Error:
       type: object
       required:

--- a/pacta/pacta.go
+++ b/pacta/pacta.go
@@ -579,6 +579,7 @@ const (
 	AuditLogAction_Download          AuditLogAction = "DOWNLOAD"
 	AuditLogAction_EnableSharing     AuditLogAction = "ENABLE_SHARING"
 	AuditLogAction_DisableSharing    AuditLogAction = "DISABLE_SHARING"
+	AuditLogAction_TransferOwnership AuditLogAction = "TRANSFER_OWNERSHIP"
 )
 
 var AuditLogActionValues = []AuditLogAction{
@@ -592,6 +593,7 @@ var AuditLogActionValues = []AuditLogAction{
 	AuditLogAction_Download,
 	AuditLogAction_EnableSharing,
 	AuditLogAction_DisableSharing,
+	AuditLogAction_TransferOwnership,
 }
 
 func ParseAuditLogAction(s string) (AuditLogAction, error) {
@@ -616,6 +618,8 @@ func ParseAuditLogAction(s string) (AuditLogAction, error) {
 		return AuditLogAction_EnableSharing, nil
 	case "DISABLE_SHARING":
 		return AuditLogAction_DisableSharing, nil
+	case "TRANSFER_OWNERSHIP":
+		return AuditLogAction_TransferOwnership, nil
 	}
 	return "", fmt.Errorf("unknown AuditLogAction: %q", s)
 }


### PR DESCRIPTION
User Merge is apparently a frequent support flow, and required some delicate thinking around audit logs. This PR implements the backend for it.

Additional changes:
- Adds a new audit log type for `TRANSFER_OWNERSHIP`
- Creates a `DeleteOwner` DB method
- Updates `DeleteUser` to do the recursive deletion of their owned assets + return blobURIs
- Updates `/delete-user` to delete the downstream blobs.