### PR TITLE
Use a single Azure topic for all our async notifications

### DIFF
--- a/cmd/runner/configs/dev.conf
+++ b/cmd/runner/configs/dev.conf
@@ -1,7 +1,7 @@
 env dev
 min_log_level warn
 
-azure_event_parse_portfolio_complete_topic parsed-portfolios-dev
+azure_event_topic pacta-events-dev
 azure_topic_location centralus-1
 
 azure_storage_account rmipactadev

--- a/cmd/runner/configs/local.conf
+++ b/cmd/runner/configs/local.conf
@@ -1,7 +1,7 @@
 env local
 min_log_level debug
 
-azure_event_parse_portfolio_complete_topic parsed-portfolios-local
+azure_event_topic pacta-events-local
 azure_topic_location centralus-1
 
 azure_storage_account rmipactalocal

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -50,8 +50,8 @@ func run(args []string) error {
 	var (
 		env = fs.String("env", "", "The environment we're running in.")
 
-		azEventParsePortfolioCompleteTopic = fs.String("azure_event_parse_portfolio_complete_topic", "", "The EventGrid topic to send notifications when parsing of portfolio(s) has finished")
-		azTopicLocation                    = fs.String("azure_topic_location", "", "The location (like 'centralus-1') where our EventGrid topics are hosted")
+		azEventTopic    = fs.String("azure_event_topic", "", "The EventGrid topic to send notifications when tasks have finished")
+		azTopicLocation = fs.String("azure_topic_location", "", "The location (like 'centralus-1') where our EventGrid topics are hosted")
 
 		azStorageAccount           = fs.String("azure_storage_account", "", "The storage account to authenticate against for blob operations")
 		azSourcePortfolioContainer = fs.String("azure_source_portfolio_container", "", "The container in the storage account where we read raw portfolios from")
@@ -100,7 +100,7 @@ func run(args []string) error {
 		}
 	}
 
-	pubsubClient, err := publisher.NewClient(fmt.Sprintf("https://%s.%s.eventgrid.azure.net/api/events", *azEventParsePortfolioCompleteTopic, *azTopicLocation), creds, nil)
+	pubsubClient, err := publisher.NewClient(fmt.Sprintf("https://%s.%s.eventgrid.azure.net/api/events", *azEventTopic, *azTopicLocation), creds, nil)
 	if err != nil {
 		return fmt.Errorf("failed to init pub/sub client: %w", err)
 	}
@@ -323,7 +323,7 @@ func (h *handler) parsePortfolio(ctx context.Context, taskID task.ID, req *task.
 				Outputs: out,
 			},
 			DataVersion: to.Ptr("1.0"),
-			EventType:   to.Ptr("parse-portfolio-complete"),
+			EventType:   to.Ptr("parsed-portfolio"),
 			EventTime:   to.Ptr(time.Now()),
 			ID:          to.Ptr(string(taskID)),
 			Subject:     to.Ptr(string(taskID)),

--- a/cmd/server/configs/dev.conf
+++ b/cmd/server/configs/dev.conf
@@ -6,4 +6,4 @@ use_azure_runner true
 
 azure_event_subscription 69b6db12-37e3-4e1f-b48c-aa41dba612a9
 azure_event_resource_group rmi-pacta-dev
-azure_event_parsed_portfolio_topic parsed-portfolios-dev
+azure_event_parsed_portfolio_topic pacta-events-dev

--- a/cmd/server/configs/local.conf
+++ b/cmd/server/configs/local.conf
@@ -3,7 +3,7 @@ allowed_cors_origin http://localhost:3000
 
 azure_event_subscription 69b6db12-37e3-4e1f-b48c-aa41dba612a9
 azure_event_resource_group rmi-pacta-local
-azure_event_parsed_portfolio_topic parsed-portfolios-local
+azure_event_topic pacta-events-local
 
 secret_postgres_host UNUSED
 # Also unused

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,9 +64,9 @@ func run(args []string) error {
 		env      = fs.String("env", "", "The environment that we're running in.")
 		localDSN = fs.String("local_dsn", "", "If set, override the DB addresses retrieved from the secret configuration. Can only be used when running locally.")
 
-		azEventSubscription         = fs.String("azure_event_subscription", "", "The Azure Subscription ID to allow webhook registrations from")
-		azEventResourceGroup        = fs.String("azure_event_resource_group", "", "The Azure resource group to allow webhook registrations from")
-		azEventParsedPortfolioTopic = fs.String("azure_event_parsed_portfolio_topic", "", "The name of the topic for webhooks about parsed portfolios")
+		azEventSubscription  = fs.String("azure_event_subscription", "", "The Azure Subscription ID to allow webhook registrations from")
+		azEventResourceGroup = fs.String("azure_event_resource_group", "", "The Azure resource group to allow webhook registrations from")
+		azEventTopic         = fs.String("azure_event_topic", "", "The name of the topic for webhooks about ecosystem updates, like parsed portfolios or created reports/audits.")
 
 		// Only when running locally because the Dockerized runner can't use local `az` CLI credentials
 		localDockerTenantID     = fs.String("local_docker_tenant_id", "", "The Azure Tenant ID the localdocker service principal lives in")
@@ -287,13 +287,13 @@ func run(args []string) error {
 	})
 
 	eventSrv, err := azevents.NewServer(&azevents.Config{
-		Logger:                   logger,
-		AllowedAuthSecrets:       strings.Split(*azEventWebhookSecrets, ","),
-		Subscription:             *azEventSubscription,
-		ResourceGroup:            *azEventResourceGroup,
-		ParsedPortfolioTopicName: *azEventParsedPortfolioTopic,
-		DB:                       db,
-		Now:                      time.Now,
+		Logger:             logger,
+		AllowedAuthSecrets: strings.Split(*azEventWebhookSecrets, ","),
+		Subscription:       *azEventSubscription,
+		ResourceGroup:      *azEventResourceGroup,
+		TopicName:          *azEventTopic,
+		DB:                 db,
+		Now:                time.Now,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to init Azure Event Grid handler: %w", err)

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -38,7 +38,7 @@ LOCAL_DOCKER_CREDS="$(echo $SOPS_DATA | jq .localdocker)"
 # TODO(#116) Set up multiple webhooks, one for each task type.
 WEBHOOK_CREDS="$(echo $SOPS_DATA | jq .webhook)"
 TOPIC_ID="$(echo $WEBHOOK_CREDS | jq -r .topic_id)"
-WEBHOOK_PATH="/events/parsed_portfolio"
+WEBHOOK_PATH="/events"
 WEBHOOK_SHARED_SECRET="$(echo $WEBHOOK_CREDS | jq -r .shared_secret)"
 
 FRP="$(echo $SOPS_DATA | jq .frpc)"

--- a/secrets/local.enc.json
+++ b/secrets/local.enc.json
@@ -10,7 +10,7 @@
 		"token": "ENC[AES256_GCM,data:qe9Hy0tKKrQ7rFzOQuTlDKGDqA2489hvEbjbtYFMuJ3wd5gy,iv:gV+OasDEHtI28TVBFmyxrPjMqEv5J1jpWMAzR1N70MQ=,tag:543oFV21kJj9qBgkyewdIg==,type:str]"
 	},
 	"webhook": {
-		"topic_id": "ENC[AES256_GCM,data:EvesYWnD9kB8/6YetDZeB5Z637xrbrfKCO6G4Cryv9s1xrD2IZNAtogV8FD5cUjk+IVsv3JWUZMu90v+xeWNoBAZMGrnGrbZniF0KKBIdJIk/jRzk9yRa5zZrLvvhF74OUcPTvoZg/iAzQ9RmT3U2Ibut9MB8qEaKib79JtOrQ6ihatkKCgdEytWH2gq0qw=,iv:DrVqTRsEsx/t27xjcrZYaY2YAclx2wPTsT1rMgs/uv8=,tag:oqsrfZxGFJKc2rWjv6zKIw==,type:str]",
+		"topic_id": "ENC[AES256_GCM,data:5WQt0jQTx8+c7SEBxhEB2bfD02wYl/FIIiDwaJtSWFvjw2RttHd7JUplqEHWdjNeZ0vbdF3iGDLfgAGHgKVLYfCpboUpEGAuGfGuzJimlJDTanFnw3wLJQ0mvTMh20Iv406yRCAXXiqJfA/qjZhfzqb2ebfiXQQoaPfGf5vgU+frD0D+kUCZvX0x,iv:5tath0izXqTQxDEcsJhRS6ATVJWxc//dLxjT9DiU280=,tag:f6I/12yGNoiG7ObgIWAGTA==,type:str]",
 		"shared_secret": "ENC[AES256_GCM,data:qzSiBGwCIX4pC8jGB2FKo1bu2EQYXj/T,iv:s94r3EzfnDWvWDXtvpktAnA9Htfd1vcGSH7iF/z6Mxs=,tag:RmhDMwasvOZvccX+QGXBhA==,type:str]"
 	},
 	"sops": {
@@ -27,8 +27,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-11-19T18:37:45Z",
-		"mac": "ENC[AES256_GCM,data:2Fm9DBQl058NR1B6dagVYE0P2Z25IaYpUvTPV94ZUFE9pXhneoAFd4pLBWjb8ciMUBX2IQ3npLn5O+Spve1UGgB6YpLbGTpxqgjOITSvcyiYqQMTAUsYIhJYoZ9NgqjkqzLExcdAAQroY83voxiKa4ycy+5WSNicZxveMhgwP80=,iv:xl11VTaad00kmktmvyQDQWuTPqxuyK/k/fRkdA/g18Y=,tag:OX+/vXbChnx6xGm66XMYwg==,type:str]",
+		"lastmodified": "2024-01-10T20:07:58Z",
+		"mac": "ENC[AES256_GCM,data:Pnma4Oe1R8hzNs5e0pG0Da0je5mS/45Nwv7bk0bkJLorsdRBWqmAJuPJQwoMmO7Uu7sl8T90fTl9Is/Nj01eYY8U+4kX3cuRUee5MzliQtgUw9v0XgPumvjrg3Th7Uo0e03wgBHk2kDkC18dpMfRIfRdBgG/6Gfsksk0PcpOYkQ=,iv:Fx5fHXYQFTsjpiv3tN2MTdUxfSxCPtTBh9rszeMUnII=,tag:TjDiM/VPF2KmgrIs4p89Mw==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"


### PR DESCRIPTION
Managing the machinery for three topics is too annoying, and it's easier and quicker and generally better to do this than set up all the local + deployed resources to make N topics work.

Instead, we use the `EventType` of a notification to indicate, well, the type of the event (e.g. `parsed-portfolio`, `created-report`, etc)

I'll send out the associated Terraform changes momentarily
