### PR TITLE
Don't create a new Azure Container Apps Job (ACAJ) every time

### DIFF
--- a/azure/aztask/aztask.go
+++ b/azure/aztask/aztask.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -23,68 +22,28 @@ type Runner struct {
 }
 
 type Config struct {
-	// Location is the location to run the runner, like centralus
-	Location string
-
-	// Identity is the account the runner should act as.
-	Identity *RunnerIdentity
-
-	Rand *rand.Rand
+	// The Azure Subscription to issue API calls against, like aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+	SubscriptionID string
+	// The resource group where our Container Apps Job is located, like rmi-pacta-{local,dev}
+	ResourceGroup string
+	// The Azure client ID of the managed identity that the job should run as, like ffffffff-0000-1111-2222-333333333333
+	ManagedIdentityClientID string
+	// The name of the Container Apps Job to start an execution of, like pacta-runner
+	JobName string
 }
 
 func (c *Config) validate() error {
-	if c.Location == "" {
-		return errors.New("no container location given")
-	}
-
-	if err := c.Identity.validate(); err != nil {
-		return fmt.Errorf("invalid identity config: %w", err)
-	}
-
-	if c.Rand == nil {
-		return errors.New("no random number generator given")
-	}
-
-	return nil
-}
-
-type RunnerIdentity struct {
-	// Like runner-local
-	Name string
-	// Like aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
-	SubscriptionID string
-	// Like rmi-pacta-{local,dev}
-	ResourceGroup string
-	// Like ffffffff-0000-1111-2222-333333333333
-	ClientID string
-	// Like pacta-{local,dev}, the name of the Container Apps Environment
-	ManagedEnvironment string
-}
-
-func (ri *RunnerIdentity) validate() error {
-	if ri.Name == "" {
-		return errors.New("no identity name given")
-	}
-	if ri.SubscriptionID == "" {
+	if c.SubscriptionID == "" {
 		return errors.New("no identity subscription ID given")
 	}
-	if ri.ResourceGroup == "" {
+	if c.ResourceGroup == "" {
 		return errors.New("no identity resource group given")
 	}
-	if ri.ClientID == "" {
+	if c.ManagedIdentityClientID == "" {
 		return errors.New("no identity client ID given")
 	}
+
 	return nil
-}
-
-func (r *RunnerIdentity) String() string {
-	tmpl := "/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s"
-	return fmt.Sprintf(tmpl, r.SubscriptionID, r.ResourceGroup, r.Name)
-}
-
-func (r *RunnerIdentity) EnvironmentID() string {
-	tmpl := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s"
-	return fmt.Sprintf(tmpl, r.SubscriptionID, r.ResourceGroup, r.ManagedEnvironment)
 }
 
 func NewRunner(creds azcore.TokenCredential, cfg *Config) (*Runner, error) {
@@ -92,37 +51,26 @@ func NewRunner(creds azcore.TokenCredential, cfg *Config) (*Runner, error) {
 		return nil, fmt.Errorf("invalid task runner config: %w", err)
 	}
 
-	clientFactory, err := armappcontainers.NewClientFactory(cfg.Identity.SubscriptionID, creds, nil)
+	clientFactory, err := armappcontainers.NewClientFactory(cfg.SubscriptionID, creds, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
-	}
-
-	gen, err := idgen.New(cfg.Rand, idgen.WithDefaultLength(32), idgen.WithCharSet([]rune("abcdefghijklmnopqrstuvwxyz")))
-	if err != nil {
-		return nil, fmt.Errorf("failed to init ID generator: %w", err)
 	}
 
 	return &Runner{
 		client: clientFactory.NewJobsClient(),
 		cfg:    cfg,
-		gen:    gen,
 	}, nil
 }
 
 func (r *Runner) Run(ctx context.Context, cfg *task.Config) (task.RunnerID, error) {
-
-	name := r.gen.NewID()
-	identity := r.cfg.Identity.String()
-	envID := r.cfg.Identity.EnvironmentID()
-
 	envVars := []*armappcontainers.EnvironmentVar{
 		{
 			Name:  to.Ptr("AZURE_CLIENT_ID"),
-			Value: to.Ptr(r.cfg.Identity.ClientID),
+			Value: to.Ptr(r.cfg.ManagedIdentityClientID),
 		},
 		{
 			Name:  to.Ptr("MANAGED_IDENTITY_CLIENT_ID"),
-			Value: to.Ptr(r.cfg.Identity.ClientID),
+			Value: to.Ptr(r.cfg.ManagedIdentityClientID),
 		},
 	}
 	for _, v := range cfg.Env {
@@ -132,75 +80,26 @@ func (r *Runner) Run(ctx context.Context, cfg *task.Config) (task.RunnerID, erro
 		})
 	}
 
-	job := armappcontainers.Job{
-		Location: &r.cfg.Location,
-		Identity: &armappcontainers.ManagedServiceIdentity{
-			Type: to.Ptr(armappcontainers.ManagedServiceIdentityTypeUserAssigned),
-			UserAssignedIdentities: map[string]*armappcontainers.UserAssignedIdentity{
-				identity: {},
-			},
+	poller, err := r.client.BeginStart(ctx, r.cfg.ResourceGroup, r.cfg.JobName, &armappcontainers.JobsClientBeginStartOptions{
+		Template: &armappcontainers.JobExecutionTemplate{
+			Containers: []*armappcontainers.JobExecutionContainer{{
+				Args:    toPtrs(cfg.Flags),
+				Command: toPtrs(cfg.Command),
+				Env:     envVars,
+				Image:   to.Ptr(cfg.Image.String()),
+				Name:    to.Ptr("pacta-runner"),
+				Resources: &armappcontainers.ContainerResources{
+					CPU:    to.Ptr(1.0),
+					Memory: to.Ptr("2Gi"),
+				},
+			}},
 		},
-		Properties: &armappcontainers.JobProperties{
-			Configuration: &armappcontainers.JobConfiguration{
-				ReplicaTimeout: to.Ptr(int32(60 * 60 * 2 /* two hours */)),
-				TriggerType:    to.Ptr(armappcontainers.TriggerTypeManual),
-				ManualTriggerConfig: &armappcontainers.JobConfigurationManualTriggerConfig{
-					// Run one copy.
-					Parallelism:            to.Ptr(int32(1)),
-					ReplicaCompletionCount: to.Ptr(int32(1)),
-				},
-				// Don't retry, if it failed once, it'll probably fail again. We might relax
-				// this in the future if we identify "transient" errors.
-				ReplicaRetryLimit: to.Ptr(int32(0)),
-				Registries: []*armappcontainers.RegistryCredentials{
-					{
-						Server:   to.Ptr(cfg.Image.Base.Registry),
-						Identity: to.Ptr(identity),
-					},
-				},
-				Secrets: []*armappcontainers.Secret{
-					// TODO: Put any useful configuration here.
-				},
-			},
-			EnvironmentID: to.Ptr(envID),
-			Template: &armappcontainers.JobTemplate{
-				Containers: []*armappcontainers.Container{
-					{
-						Args:    toPtrs(cfg.Flags),
-						Command: toPtrs(cfg.Command),
-						Env:     envVars,
-						Image:   to.Ptr(cfg.Image.String()),
-						Name:    to.Ptr(name),
-						Probes:  []*armappcontainers.ContainerAppProbe{},
-						Resources: &armappcontainers.ContainerResources{
-							CPU:    to.Ptr(1.0),
-							Memory: to.Ptr("2Gi"),
-						},
-						VolumeMounts: []*armappcontainers.VolumeMount{},
-					},
-				},
-				Volumes: []*armappcontainers.Volume{
-					// TODO: Mount any sources here.
-				},
-			},
-		},
-		Tags: map[string]*string{},
-	}
-	poller, err := r.client.BeginCreateOrUpdate(ctx, r.cfg.Identity.ResourceGroup, name, job, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create container app job: %w", err)
-	}
-
-	res, err := poller.PollUntilDone(ctx, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to poll container group creation: %w", err)
-	}
-
-	poller2, err := r.client.BeginStart(ctx, r.cfg.Identity.ResourceGroup, name, nil)
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to start container app job: %w", err)
 	}
-	if _, err := poller2.PollUntilDone(ctx, nil); err != nil {
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
 		return "", fmt.Errorf("failed to poll for container app start: %w", err)
 	}
 

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "@com_github_lestrrat_go_jwx_v2//jwk",
         "@com_github_namsral_flag//:flag",
         "@com_github_rs_cors//:cors",
-        "@com_github_silicon_ally_cryptorand//:cryptorand",
         "@com_github_silicon_ally_zaphttplog//:zaphttplog",
         "@org_uber_go_zap//:zap",
     ],

--- a/cmd/server/configs/local.conf
+++ b/cmd/server/configs/local.conf
@@ -19,12 +19,10 @@ secret_auth_public_key_data -----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAP/Sv7H5T
 secret_azure_storage_account rmipactalocal
 secret_azure_source_portfolio_container uploadedportfolios
 
-secret_runner_config_location centralus
 secret_runner_config_config_path /configs/local.conf
-secret_runner_config_identity_name pacta-runner-local
-secret_runner_config_identity_subscription_id 69b6db12-37e3-4e1f-b48c-aa41dba612a9
-secret_runner_config_identity_resource_group rmi-pacta-local
-secret_runner_config_identity_client_id c02b7346-6ba6-438a-8136-1ccb608e5449
-secret_runner_config_identity_managed_environment pacta-local
+secret_runner_config_subscription_id 69b6db12-37e3-4e1f-b48c-aa41dba612a9
+secret_runner_config_resource_group rmi-pacta-local
+secret_runner_config_managed_identity_client_id c02b7346-6ba6-438a-8136-1ccb608e5449
+secret_runner_config_job_name pacta-runner
 secret_runner_config_image_registry rmisa.azurecr.io
 secret_runner_config_image_name runner

--- a/cmd/server/configs/local.conf
+++ b/cmd/server/configs/local.conf
@@ -23,6 +23,6 @@ secret_runner_config_config_path /configs/local.conf
 secret_runner_config_subscription_id 69b6db12-37e3-4e1f-b48c-aa41dba612a9
 secret_runner_config_resource_group rmi-pacta-local
 secret_runner_config_managed_identity_client_id c02b7346-6ba6-438a-8136-1ccb608e5449
-secret_runner_config_job_name pacta-runner
+secret_runner_config_job_name pacta-runner-local
 secret_runner_config_image_registry rmisa.azurecr.io
 secret_runner_config_image_name runner

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -25,18 +25,13 @@ type AuthVerificationKey struct {
 }
 
 type RunnerConfig struct {
-	Location   string
 	ConfigPath string
-	Identity   RunnerIdentity
 	Image      RunnerImage
-}
 
-type RunnerIdentity struct {
-	Name               string
-	SubscriptionID     string
-	ResourceGroup      string
-	ClientID           string
-	ManagedEnvironment string
+	SubscriptionID          string
+	ResourceGroup           string
+	ManagedIdentityClientID string
+	JobName                 string
 }
 
 type RunnerImage struct {
@@ -56,18 +51,13 @@ type RawAuthVerificationKey struct {
 }
 
 type RawRunnerConfig struct {
-	Location   string
 	ConfigPath string
-	Identity   *RawRunnerIdentity
 	Image      *RawRunnerImage
-}
 
-type RawRunnerIdentity struct {
-	Name               string
-	SubscriptionID     string
-	ResourceGroup      string
-	ClientID           string
-	ManagedEnvironment string
+	SubscriptionID          string
+	ResourceGroup           string
+	ManagedIdentityClientID string
+	JobName                 string
 }
 
 type RawRunnerImage struct {
@@ -208,10 +198,6 @@ func parseRunnerConfig(cfg *RawRunnerConfig) (RunnerConfig, error) {
 		return RunnerConfig{}, errors.New("no runner config was provided")
 	}
 
-	if cfg.Location == "" {
-		return RunnerConfig{}, errors.New("no runner_config.location was provided")
-	}
-
 	if cfg.Image == nil {
 		return RunnerConfig{}, errors.New("no runner_config.image was provided")
 	}
@@ -226,35 +212,23 @@ func parseRunnerConfig(cfg *RawRunnerConfig) (RunnerConfig, error) {
 		return RunnerConfig{}, errors.New("no runner_config.config_path was provided")
 	}
 
-	if cfg.Identity == nil {
-		return RunnerConfig{}, errors.New("no runner_config.identity was provided")
+	if cfg.SubscriptionID == "" {
+		return RunnerConfig{}, errors.New("no runner_config.subscription_id was provided")
 	}
-	if cfg.Identity.Name == "" {
-		return RunnerConfig{}, errors.New("no runner_config.identity.name was provided")
+	if cfg.ResourceGroup == "" {
+		return RunnerConfig{}, errors.New("no runner_config.resource_group was provided")
 	}
-	if cfg.Identity.SubscriptionID == "" {
-		return RunnerConfig{}, errors.New("no runner_config.identity.subscription_id was provided")
-	}
-	if cfg.Identity.ResourceGroup == "" {
-		return RunnerConfig{}, errors.New("no runner_config.identity.resource_group was provided")
-	}
-	if cfg.Identity.ClientID == "" {
-		return RunnerConfig{}, errors.New("no runner_config.identity.client_id was provided")
-	}
-	if cfg.Identity.ManagedEnvironment == "" {
-		return RunnerConfig{}, errors.New("no runner_config.identity.managed_environment was provided")
+	if cfg.ManagedIdentityClientID == "" {
+		return RunnerConfig{}, errors.New("no runner_config.managed_identity_client_id was provided")
 	}
 
 	return RunnerConfig{
-		Location:   cfg.Location,
 		ConfigPath: cfg.ConfigPath,
-		Identity: RunnerIdentity{
-			Name:               cfg.Identity.Name,
-			SubscriptionID:     cfg.Identity.SubscriptionID,
-			ResourceGroup:      cfg.Identity.ResourceGroup,
-			ClientID:           cfg.Identity.ClientID,
-			ManagedEnvironment: cfg.Identity.ManagedEnvironment,
-		},
+
+		SubscriptionID:          cfg.SubscriptionID,
+		ResourceGroup:           cfg.ResourceGroup,
+		ManagedIdentityClientID: cfg.ManagedIdentityClientID,
+		JobName:                 cfg.JobName,
 		Image: RunnerImage{
 			Registry: cfg.Image.Registry,
 			Name:     cfg.Image.Name,


### PR DESCRIPTION
It turns out that the way Azure intends you to use Container Apps Jobs is to create a single 'job' and then invoke it (optionally changing the command/image/etc).

'Jobs' are more like 'templates', and are fairly heavy to create. This PR changes our config to just run things against and existing ACAJ, which makes everything much faster.
