### PR TITLE
Update generated OAPI bindings, fix enum conv, other small bugs

### DIFF
--- a/cmd/server/pactasrv/analysis.go
+++ b/cmd/server/pactasrv/analysis.go
@@ -139,20 +139,20 @@ func (s *Server) RunAnalysis(ctx context.Context, request api.RunAnalysisRequest
 		return nil, err
 	}
 
-	analysisType, err := conv.AnalysisTypeFromOAPI(&request.Body.AnalysisType)
+	analysisType, err := conv.AnalysisTypeFromOAPI(request.Body.AnalysisType)
 	if err != nil {
 		return nil, err
 	}
 
 	var ais []entityForAnalysis
 	if request.Body.InitiativeId != nil {
-		ais = append(ais, initiativeAnalysis{iID: pacta.InitiativeID(*request.Body.InitiativeId), s: s})
+		ais = append(ais, &initiativeAnalysis{iID: pacta.InitiativeID(*request.Body.InitiativeId), s: s})
 	}
 	if request.Body.PortfolioGroupId != nil {
-		ais = append(ais, portfolioGroupAnalysis{pgID: pacta.PortfolioGroupID(*request.Body.PortfolioGroupId), s: s})
+		ais = append(ais, &portfolioGroupAnalysis{pgID: pacta.PortfolioGroupID(*request.Body.PortfolioGroupId), s: s})
 	}
 	if request.Body.PortfolioId != nil {
-		ais = append(ais, portfolioAnalysis{pID: pacta.PortfolioID(*request.Body.PortfolioId), s: s})
+		ais = append(ais, &portfolioAnalysis{pID: pacta.PortfolioID(*request.Body.PortfolioId), s: s})
 	}
 	if len(ais) == 0 {
 		return nil, oapierr.BadRequest("one of initiative_id, portfolio_group_id, or portfolio_id is required")
@@ -200,7 +200,7 @@ func (s *Server) RunAnalysis(ctx context.Context, request api.RunAnalysisRequest
 		}
 
 		aID, err := s.DB.CreateAnalysis(tx, &pacta.Analysis{
-			AnalysisType:      *analysisType,
+			AnalysisType:      analysisType,
 			PortfolioSnapshot: &pacta.PortfolioSnapshot{ID: snapshotID},
 			PACTAVersion:      &pacta.PACTAVersion{ID: pvID},
 			Owner:             &pacta.Owner{ID: actorInfo.OwnerID},
@@ -216,7 +216,7 @@ func (s *Server) RunAnalysis(ctx context.Context, request api.RunAnalysisRequest
 			ActorOwner:         &pacta.Owner{ID: actorInfo.OwnerID},
 			Action:             pacta.AuditLogAction_Create,
 			PrimaryTargetType:  pacta.AuditLogTargetType_Analysis,
-			PrimaryTargetID:    string(analysisID),
+			PrimaryTargetID:    string(aID),
 			PrimaryTargetOwner: &pacta.Owner{ID: actorInfo.OwnerID},
 		}); err != nil {
 			return fmt.Errorf("creating audit log: %w", err)
@@ -232,7 +232,7 @@ func (s *Server) RunAnalysis(ctx context.Context, request api.RunAnalysisRequest
 		return nil, oapierr.Internal("failed to create analysis", zap.Error(err))
 	}
 
-	switch *analysisType {
+	switch analysisType {
 	case pacta.AnalysisType_Audit:
 		taskID, runnerID, err := s.TaskRunner.CreateAudit(ctx, &task.CreateAuditRequest{
 			AnalysisID: analysisID,
@@ -252,7 +252,7 @@ func (s *Server) RunAnalysis(ctx context.Context, request api.RunAnalysisRequest
 		}
 		s.Logger.Info("created report task", zap.String("task_id", string(taskID)), zap.String("runner_id", string(runnerID)), zap.String("analysis_id", string(analysisID)))
 	default:
-		return nil, oapierr.Internal("unknown analysis type", zap.String("analysis_type", string(*analysisType)))
+		return nil, oapierr.Internal("unknown analysis type", zap.String("analysis_type", string(analysisType)))
 	}
 
 	return api.RunAnalysis200JSONResponse{AnalysisId: string(analysisID)}, nil
@@ -278,7 +278,7 @@ func notFoundErr[T ~string](typeName string, id T, fields ...zapcore.Field) erro
 	return oapierr.NotFound(fmt.Sprintf("%s not found", typeName), fs...)
 }
 
-func (pa portfolioAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
+func (pa *portfolioAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
 	actorInfo, err := pa.s.getActorInfoOrErrIfAnon(ctx)
 	if err != nil {
 		return err
@@ -300,7 +300,7 @@ func (pa portfolioAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
 	return nil
 }
 
-func (pa portfolioAnalysis) createSnapshot(tx db.Tx) (pacta.PortfolioSnapshotID, []pacta.BlobID, error) {
+func (pa *portfolioAnalysis) createSnapshot(tx db.Tx) (pacta.PortfolioSnapshotID, []pacta.BlobID, error) {
 	sID, err := pa.s.DB.CreateSnapshotOfPortfolio(tx, pa.pID)
 	if err != nil {
 		return "", nil, fmt.Errorf("creating snapshot of portfolio: %w", err)
@@ -315,7 +315,7 @@ type portfolioGroupAnalysis struct {
 	pg *pacta.PortfolioGroup
 }
 
-func (pga portfolioGroupAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
+func (pga *portfolioGroupAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
 	actorInfo, err := pga.s.getActorInfoOrErrIfAnon(ctx)
 	if err != nil {
 		return err
@@ -337,7 +337,7 @@ func (pga portfolioGroupAnalysis) checkAuth(ctx context.Context, tx db.Tx) error
 	return nil
 }
 
-func (pga portfolioGroupAnalysis) createSnapshot(tx db.Tx) (pacta.PortfolioSnapshotID, []pacta.BlobID, error) {
+func (pga *portfolioGroupAnalysis) createSnapshot(tx db.Tx) (pacta.PortfolioSnapshotID, []pacta.BlobID, error) {
 	sID, err := pga.s.DB.CreateSnapshotOfPortfolioGroup(tx, pga.pgID)
 	if err != nil {
 		return "", nil, fmt.Errorf("creating snapshot of portfolio group: %w", err)
@@ -364,7 +364,7 @@ type initiativeAnalysis struct {
 	i *pacta.Initiative
 }
 
-func (ia initiativeAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
+func (ia *initiativeAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
 	// This crudely tests whether or not a user is a manager of the initiative.
 	if err := ia.s.initiativeDoAuthzAndAuditLog(ctx, ia.iID, pacta.AuditLogAction_Update); err != nil {
 		return err
@@ -380,7 +380,7 @@ func (ia initiativeAnalysis) checkAuth(ctx context.Context, tx db.Tx) error {
 	return nil
 }
 
-func (ia initiativeAnalysis) createSnapshot(tx db.Tx) (pacta.PortfolioSnapshotID, []pacta.BlobID, error) {
+func (ia *initiativeAnalysis) createSnapshot(tx db.Tx) (pacta.PortfolioSnapshotID, []pacta.BlobID, error) {
 	sID, err := ia.s.DB.CreateSnapshotOfInitiative(tx, ia.iID)
 	if err != nil {
 		return "", nil, fmt.Errorf("creating snapshot of initiative: %w", err)

--- a/cmd/server/pactasrv/conv/conv_test.go
+++ b/cmd/server/pactasrv/conv/conv_test.go
@@ -22,6 +22,10 @@ func TestAuditLogTargetTypeRoundTrip(t *testing.T) {
 	testEnumConvertability(t, pacta.AuditLogTargetTypeValues, auditLogTargetTypeToOAPI, auditLogTargetTypeFromOAPI)
 }
 
+func TestAnalysisTypeRoundTrip(t *testing.T) {
+	testEnumConvertability(t, pacta.AnalysisTypeValues, AnalysisTypeToOAPI, AnalysisTypeFromOAPI)
+}
+
 func testEnumConvertability[A comparable, B any](t *testing.T, as []A, aToB func(in A) (B, error), bToA func(in B) (A, error)) {
 	for _, a := range as {
 		b, err := aToB(a)

--- a/cmd/server/pactasrv/conv/oapi_to_pacta.go
+++ b/cmd/server/pactasrv/conv/oapi_to_pacta.go
@@ -83,17 +83,14 @@ func InitiativeInvitationFromOAPI(i *api.InitiativeInvitationCreate) (*pacta.Ini
 	}, nil
 }
 
-func AnalysisTypeFromOAPI(at *api.AnalysisType) (*pacta.AnalysisType, error) {
-	if at == nil {
-		return nil, oapierr.BadRequest("analysisTypeFromOAPI: can't convert nil pointer")
+func AnalysisTypeFromOAPI(at api.AnalysisType) (pacta.AnalysisType, error) {
+	switch at {
+	case api.AnalysisTypeAUDIT:
+		return pacta.AnalysisType_Audit, nil
+	case api.AnalysisTypeREPORT:
+		return pacta.AnalysisType_Report, nil
 	}
-	switch string(*at) {
-	case "audit":
-		return ptr(pacta.AnalysisType_Audit), nil
-	case "report":
-		return ptr(pacta.AnalysisType_Report), nil
-	}
-	return nil, oapierr.BadRequest("analysisTypeFromOAPI: unknown analysis type", zap.String("analysis_type", string(*at)))
+	return "", oapierr.BadRequest("analysisTypeFromOAPI: unknown analysis type", zap.String("analysis_type", string(at)))
 }
 
 func HoldingsDateFromOAPI(hd *api.HoldingsDate) (*pacta.HoldingsDate, error) {

--- a/frontend/components/portfolio/ListView.vue
+++ b/frontend/components/portfolio/ListView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { portfolioEditor } from '@/lib/editor'
-import { type Portfolio, type PortfolioGroup, type Initiative } from '@/openapi/generated/pacta'
+import { AnalysisType, type Portfolio, type PortfolioGroup, type Initiative } from '@/openapi/generated/pacta'
 import { selectedCountSuffix } from '@/lib/selection'
 
 const {
@@ -66,6 +66,19 @@ const saveChanges = (id: string) => {
     `${prefix}.saveChanges`,
   )
 }
+
+const runAnalysis = (id: string) => {
+  return withLoading(
+    () => pactaClient.runAnalysis({
+      analysisType: AnalysisType.ANALYSIS_TYPE_REPORT,
+      name: 'Test Analysis!',
+      description: 'this is a test',
+      portfolioId: id,
+    }).then(() => { emit('refresh') }),
+    `${prefix}.saveChanges`,
+  )
+}
+
 const deletePortfolio = (id: string) => withLoading(
   () => pactaClient.deletePortfolio(id),
   `${prefix}.deletePortfolio`,
@@ -226,6 +239,10 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
                 @click="() => saveChanges(slotProps.data.id)"
               />
             </div>
+            <PVButton
+              label="Test Run Analysis"
+              @click="() => runAnalysis(slotProps.data.id)"
+            />
           </div>
         </div>
       </template>

--- a/frontend/openapi/generated/pacta/index.ts
+++ b/frontend/openapi/generated/pacta/index.ts
@@ -56,6 +56,8 @@ export type { ListPortfolioGroupsReq } from './models/ListPortfolioGroupsReq';
 export type { ListPortfolioGroupsResp } from './models/ListPortfolioGroupsResp';
 export type { ListPortfoliosReq } from './models/ListPortfoliosReq';
 export type { ListPortfoliosResp } from './models/ListPortfoliosResp';
+export type { MergeUsersReq } from './models/MergeUsersReq';
+export type { MergeUsersResp } from './models/MergeUsersResp';
 export type { NewPortfolioAsset } from './models/NewPortfolioAsset';
 export type { PactaVersion } from './models/PactaVersion';
 export type { PactaVersionChanges } from './models/PactaVersionChanges';

--- a/frontend/openapi/generated/pacta/models/AuditLogAction.ts
+++ b/frontend/openapi/generated/pacta/models/AuditLogAction.ts
@@ -15,4 +15,5 @@ export enum AuditLogAction {
     AUDIT_LOG_ACTION_ENABLE_SHARING = 'AuditLogActionEnableSharing',
     AUDIT_LOG_ACTION_DISABLE_SHARING = 'AuditLogActionDisableSharing',
     AUDIT_LOG_ACTION_READ_METADATA = 'AuditLogActionReadMetadata',
+    AUDIT_LOG_ACTION_TRANSFER_OWNERSHIP = 'AuditLogActionTransferOwnership',
 }

--- a/frontend/openapi/generated/pacta/models/MergeUsersReq.ts
+++ b/frontend/openapi/generated/pacta/models/MergeUsersReq.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type MergeUsersReq = {
+    /**
+     * the user id of the user to merge records from, and to be deleted after the merge
+     */
+    fromUserId: string;
+    /**
+     * the user id of the user to recieve merged records and to exist after the merge
+     */
+    toUserId: string;
+};
+

--- a/frontend/openapi/generated/pacta/models/MergeUsersResp.ts
+++ b/frontend/openapi/generated/pacta/models/MergeUsersResp.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type MergeUsersResp = {
+    /**
+     * the number of incomplete uploads that were transferred to the new user
+     */
+    incompleteUploadCount: number;
+    /**
+     * the number of analyses that were transferred to the new user
+     */
+    analysisCount: number;
+    /**
+     * the number of portfolios that were transferred to the new user
+     */
+    portfolioCount: number;
+    /**
+     * the number of portfolio groups that were transferred to the new user
+     */
+    portfolioGroupCount: number;
+    /**
+     * the number of audit logs that were created to record the merge
+     */
+    auditLogsCreated: number;
+};
+

--- a/frontend/openapi/generated/pacta/services/DefaultService.ts
+++ b/frontend/openapi/generated/pacta/services/DefaultService.ts
@@ -25,6 +25,8 @@ import type { ListAnalysesResp } from '../models/ListAnalysesResp';
 import type { ListIncompleteUploadsResp } from '../models/ListIncompleteUploadsResp';
 import type { ListPortfolioGroupsResp } from '../models/ListPortfolioGroupsResp';
 import type { ListPortfoliosResp } from '../models/ListPortfoliosResp';
+import type { MergeUsersReq } from '../models/MergeUsersReq';
+import type { MergeUsersResp } from '../models/MergeUsersResp';
 import type { PactaVersion } from '../models/PactaVersion';
 import type { PactaVersionChanges } from '../models/PactaVersionChanges';
 import type { PactaVersionCreate } from '../models/PactaVersionCreate';
@@ -169,6 +171,24 @@ export class DefaultService {
         return this.httpRequest.request({
             method: 'POST',
             url: '/pacta-versions',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Merges two users together
+     * Merges two users together
+     * @param requestBody a request describing the two users to merge
+     * @returns MergeUsersResp the users were merged successfully
+     * @throws ApiError
+     */
+    public mergeUsers(
+        requestBody: MergeUsersReq,
+    ): CancelablePromise<MergeUsersResp> {
+        return this.httpRequest.request({
+            method: 'POST',
+            url: '/admin/merge-users',
             body: requestBody,
             mediaType: 'application/json',
         });


### PR DESCRIPTION
Fix a few unrelated issues that came up while testing non-parse-portfolio async tasks

Also adds a basic `Test Run Analysis` button to the `PortfolioListView` to help test stuff
