### PR TITLE
Add support for serving the static assets in a report

### DIFF
--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//dockertask",
         "//oapierr",
         "//openapi:pacta_generated",
+        "//reportsrv",
         "//secrets",
         "//session",
         "//task",

--- a/reportsrv/BUILD.bazel
+++ b/reportsrv/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "reportsrv",
+    srcs = ["reportsrv.go"],
+    importpath = "github.com/RMI/pacta/reportsrv",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//blob",
+        "//db",
+        "//pacta",
+        "@com_github_go_chi_chi_v5//:chi",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "reportsrv_test",
+    srcs = ["reportsrv_test.go"],
+    embed = [":reportsrv"],
+    deps = [
+        "//blob",
+        "//db",
+        "//pacta",
+        "@com_github_go_chi_chi_v5//:chi",
+        "@org_uber_go_zap//zaptest",
+    ],
+)

--- a/reportsrv/reportsrv.go
+++ b/reportsrv/reportsrv.go
@@ -1,0 +1,181 @@
+package reportsrv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/RMI/pacta/blob"
+	"github.com/RMI/pacta/db"
+	"github.com/RMI/pacta/pacta"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+type Config struct {
+	DB     DB
+	Blob   Blob
+	Logger *zap.Logger
+}
+
+func (c *Config) validate() error {
+	if c.DB == nil {
+		return errors.New("no DB was given")
+	}
+	if c.Blob == nil {
+		return errors.New("no blob client was given")
+	}
+	if c.Logger == nil {
+		return errors.New("no logger was given")
+	}
+	return nil
+}
+
+type Server struct {
+	db     DB
+	blob   Blob
+	logger *zap.Logger
+}
+
+type DB interface {
+	Begin(context.Context) (db.Tx, error)
+	NoTxn(context.Context) db.Tx
+	Transactional(context.Context, func(tx db.Tx) error) error
+	RunOrContinueTransaction(db.Tx, func(tx db.Tx) error) error
+
+	AnalysisArtifactsForAnalysis(tx db.Tx, id pacta.AnalysisID) ([]*pacta.AnalysisArtifact, error)
+	Blobs(tx db.Tx, ids []pacta.BlobID) (map[pacta.BlobID]*pacta.Blob, error)
+}
+
+type Blob interface {
+	Scheme() blob.Scheme
+
+	ReadBlob(ctx context.Context, uri string) (io.ReadCloser, error)
+}
+
+func New(cfg *Config) (*Server, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	return &Server{
+		db:     cfg.DB,
+		blob:   cfg.Blob,
+		logger: cfg.Logger,
+	}, nil
+}
+
+func (s *Server) verifyRequest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO(#12): Figure out how to share authz between the main pactasrv and this.
+		// Should be a fast follow, but large enough to be a separate change.
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) RegisterHandlers(r chi.Router) {
+	r.Use(s.verifyRequest)
+	r.Get("/report/{analysis_id}/*", s.serveReport)
+}
+
+func (s *Server) serveReport(w http.ResponseWriter, r *http.Request) {
+	aID := pacta.AnalysisID(chi.URLParam(r, "analysis_id"))
+	if aID == "" {
+		http.Error(w, "no id given", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+
+	artifacts, err := s.db.AnalysisArtifactsForAnalysis(s.db.NoTxn(ctx), aID)
+	if err != nil {
+		http.Error(w, "failed to get artifacts: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var blobIDs []pacta.BlobID
+	for _, a := range artifacts {
+		blobIDs = append(blobIDs, a.Blob.ID)
+	}
+
+	blobs, err := s.db.Blobs(s.db.NoTxn(ctx), blobIDs)
+	if err != nil {
+		http.Error(w, "failed to get blobs: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	subPath := strings.TrimPrefix(r.URL.Path, "/report/"+string(aID))
+	if strings.HasPrefix(subPath, "/") {
+		subPath = subPath[1:]
+	}
+	if subPath == "" {
+		subPath = "index.html"
+	}
+
+	for _, a := range artifacts {
+		// Container is just 'reports', we can ignore that.
+		b, ok := blobs[a.Blob.ID]
+		if !ok {
+			s.logger.Error("no blob loaded for blob ID", zap.String("analysis_artifact_id", string(a.ID)), zap.String("blob_id", string(a.Blob.ID)))
+			continue
+		}
+		uri := string(b.BlobURI)
+		_, path, ok := blob.SplitURI(s.blob.Scheme(), uri)
+		if !ok {
+			s.logger.Error("blob had invalid URI", zap.String("analysis_artifact_id", string(a.ID)), zap.String("blob_uri", uri))
+			continue
+		}
+		_, uriPath, ok := strings.Cut(path, "/")
+		if !ok {
+			s.logger.Error("path had no UUID prefix", zap.String("analysis_artifact_id", string(a.ID)), zap.String("blob_uri", uri), zap.String("blob_path", path))
+			continue
+		}
+
+		if uriPath != subPath {
+			continue
+		}
+
+		r, err := s.blob.ReadBlob(ctx, uri)
+		if err != nil {
+			http.Error(w, "failed to read blob: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer r.Close()
+		w.Header().Set("Content-Type", fileTypeToMIME(b.FileType))
+		if _, err := io.Copy(w, r); err != nil {
+			http.Error(w, "failed to read/write blob: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+	http.Error(w, "not found", http.StatusNotFound)
+	return
+}
+
+func fileTypeToMIME(ft pacta.FileType) string {
+	switch ft {
+	case pacta.FileType_CSV:
+		return "text/csv"
+	case pacta.FileType_YAML:
+		// Note: This one is actually kinda contentious, but I don't think it matters
+		// much. See https://stackoverflow.com/q/332129
+		return "text/yaml"
+	case pacta.FileType_ZIP:
+		return "application/zip"
+	case pacta.FileType_HTML:
+		return "text/html"
+	case pacta.FileType_JSON:
+		return "application/json"
+	case pacta.FileType_TEXT:
+		return "text/plain"
+	case pacta.FileType_CSS:
+		return "text/css"
+	case pacta.FileType_JS:
+		return "text/javascript"
+	case pacta.FileType_TTF:
+		return "font/ttf"
+	default:
+		return "application/octet-stream"
+	}
+
+}

--- a/reportsrv/reportsrv_test.go
+++ b/reportsrv/reportsrv_test.go
@@ -125,20 +125,8 @@ type testDB struct {
 	blobs             map[pacta.BlobID]*pacta.Blob
 }
 
-func (tdb *testDB) Begin(ctx context.Context) (db.Tx, error) {
-	return testTx{}, nil
-}
-
 func (tdb *testDB) NoTxn(ctx context.Context) db.Tx {
 	return testTx{}
-}
-
-func (tdb *testDB) Transactional(ctx context.Context, fn func(tx db.Tx) error) error {
-	return fn(testTx{})
-}
-
-func (tdb *testDB) RunOrContinueTransaction(tx db.Tx, fn func(tx db.Tx) error) error {
-	return fn(testTx{})
 }
 
 func (tdb *testDB) AnalysisArtifactsForAnalysis(tx db.Tx, id pacta.AnalysisID) ([]*pacta.AnalysisArtifact, error) {

--- a/reportsrv/reportsrv_test.go
+++ b/reportsrv/reportsrv_test.go
@@ -1,0 +1,175 @@
+package reportsrv
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/RMI/pacta/blob"
+	"github.com/RMI/pacta/db"
+	"github.com/RMI/pacta/pacta"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestServeReport(t *testing.T) {
+	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+		URLParams: chi.RouteParams{
+			Keys:   []string{"analysis_id"},
+			Values: []string{"analysis.id1"},
+		},
+	})
+
+	srv, env := setup(t)
+
+	env.db.analysisArtifacts = []*pacta.AnalysisArtifact{
+		&pacta.AnalysisArtifact{
+			ID:         "analysisartifact.id1",
+			AnalysisID: "analysis.id1",
+			Blob:       &pacta.Blob{ID: "blob.id1"},
+		},
+		&pacta.AnalysisArtifact{
+			ID:         "analysisartifact.id2",
+			AnalysisID: "analysis.id1",
+			Blob:       &pacta.Blob{ID: "blob.id2"},
+		},
+	}
+
+	env.db.blobs = map[pacta.BlobID]*pacta.Blob{
+		"blob.id1": &pacta.Blob{
+			ID:       "blob.id1",
+			BlobURI:  "test://reports/1111-2222-3333-4444/index.html",
+			FileType: pacta.FileType_HTML,
+			FileName: "index.html",
+		},
+		"blob.id2": &pacta.Blob{
+			ID:       "blob.id2",
+			BlobURI:  "test://reports/1111-2222-3333-4444/lib/some/package.js",
+			FileType: pacta.FileType_JS,
+			FileName: "package.js",
+		},
+	}
+
+	htmlContent := "<html>this is the index</html>"
+	jsContent := "function() { return 'some js' }"
+	env.blob.blobContents = map[string]string{
+		"test://reports/1111-2222-3333-4444/index.html":          htmlContent,
+		"test://reports/1111-2222-3333-4444/lib/some/package.js": jsContent,
+	}
+
+	serveReportAndCheckResponse := func(path, contentType, responseBody string) {
+		t.Run(path, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, path, nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			srv.serveReport(w, r)
+
+			res := w.Result()
+			// Successful response...
+			if got, want := w.Code, http.StatusOK; got != want {
+				t.Errorf("got status code %d, want %d", got, want)
+			}
+			// ...with the correct content-type...
+			if got, want := res.Header.Get("Content-Type"), contentType; got != want {
+				t.Errorf("Content-Type = %q, want %q", got, want)
+			}
+			// ...and the correct response body.
+			if got, want := w.Body.String(), responseBody; got != want {
+				t.Errorf("Response body = %q, want %q", got, want)
+			}
+		})
+	}
+
+	// First, request the root in a few different ways. All of then should return the /index.html file contents.
+	serveReportAndCheckResponse("/report/analysis.id1", "text/html", htmlContent)
+	serveReportAndCheckResponse("/report/analysis.id1/", "text/html", htmlContent)
+	serveReportAndCheckResponse("/report/analysis.id1/index.html", "text/html", htmlContent)
+
+	// Now, try loading an asset from the report.
+	serveReportAndCheckResponse("/report/analysis.id1/lib/some/package.js", "text/javascript", jsContent)
+}
+
+type testEnv struct {
+	db   *testDB
+	blob *testBlob
+}
+
+func setup(t *testing.T) (*Server, *testEnv) {
+	env := &testEnv{
+		db:   &testDB{},
+		blob: &testBlob{},
+	}
+
+	return &Server{
+		db:     env.db,
+		blob:   env.blob,
+		logger: zaptest.NewLogger(t),
+	}, env
+}
+
+type testTx struct{}
+
+func (testTx) Commit() error   { return nil }
+func (testTx) Rollback() error { return nil }
+
+type testDB struct {
+	// Recording inputs
+	gotAnalysisIDs []pacta.AnalysisID
+	gotBlobIDs     [][]pacta.BlobID
+
+	// Hardcoded outputs
+	analysisArtifacts []*pacta.AnalysisArtifact
+	blobs             map[pacta.BlobID]*pacta.Blob
+}
+
+func (tdb *testDB) Begin(ctx context.Context) (db.Tx, error) {
+	return testTx{}, nil
+}
+
+func (tdb *testDB) NoTxn(ctx context.Context) db.Tx {
+	return testTx{}
+}
+
+func (tdb *testDB) Transactional(ctx context.Context, fn func(tx db.Tx) error) error {
+	return fn(testTx{})
+}
+
+func (tdb *testDB) RunOrContinueTransaction(tx db.Tx, fn func(tx db.Tx) error) error {
+	return fn(testTx{})
+}
+
+func (tdb *testDB) AnalysisArtifactsForAnalysis(tx db.Tx, id pacta.AnalysisID) ([]*pacta.AnalysisArtifact, error) {
+	tdb.gotAnalysisIDs = append(tdb.gotAnalysisIDs, id)
+	return tdb.analysisArtifacts, nil
+}
+
+func (tdb *testDB) Blobs(tx db.Tx, ids []pacta.BlobID) (map[pacta.BlobID]*pacta.Blob, error) {
+	tdb.gotBlobIDs = append(tdb.gotBlobIDs, ids)
+	return tdb.blobs, nil
+}
+
+type testBlob struct {
+	// Recording input
+	gotURIs []string
+
+	// Hardcoded output, mapping of uri -> contents
+	blobContents map[string]string
+}
+
+func (tb *testBlob) Scheme() blob.Scheme {
+	return blob.Scheme("test")
+}
+
+type noopCloser struct {
+	io.Reader
+}
+
+func (noopCloser) Close() error { return nil }
+
+func (tb *testBlob) ReadBlob(ctx context.Context, uri string) (io.ReadCloser, error) {
+	tb.gotURIs = append(tb.gotURIs, uri)
+	return noopCloser{strings.NewReader(tb.blobContents[uri])}, nil
+}


### PR DESCRIPTION
This PR adds a new `/report/<analysis ID>` endpoint that serves a report. Importantly, this is a _server_ endpoint, our Nuxt client knows nothing about it.

That means to test it locally, you go to `localhost:8081/report/<analysis ID>`, and when deployed, it'll be `https://pacta-api.dev.rmi.siliconally.dev/report/<analysis ID>` IIRC. Since we share cookies between `*.dev.rmi.siliconally.dev`, this works fine.

The main thing missing from this PR is authz, which will be the next thing I do.
