### PR TITLE
Barebones Analysis Display + Audit Logs

### DIFF
--- a/cmd/server/pactasrv/analysis.go
+++ b/cmd/server/pactasrv/analysis.go
@@ -25,6 +25,16 @@ func (s *Server) ListAnalyses(ctx context.Context, request api.ListAnalysesReque
 	if err != nil {
 		return nil, oapierr.Internal("failed to query analyses", zap.Error(err))
 	}
+	if err := s.populateArtifactsInAnalyses(ctx, as...); err != nil {
+		return nil, err
+	}
+	artifacts := []*pacta.AnalysisArtifact{}
+	for _, a := range as {
+		artifacts = append(artifacts, a.Artifacts...)
+	}
+	if err := s.populateBlobsInAnalysisArtifacts(ctx, artifacts...); err != nil {
+		return nil, err
+	}
 	items, err := dereference(conv.AnalysesToOAPI(as))
 	if err != nil {
 		return nil, err

--- a/cmd/server/pactasrv/conv/pacta_to_oapi.go
+++ b/cmd/server/pactasrv/conv/pacta_to_oapi.go
@@ -314,8 +314,18 @@ func FileTypeToOAPI(ft pacta.FileType) (api.FileType, error) {
 		return api.FileTypeJSON, nil
 	case pacta.FileType_HTML:
 		return api.FileTypeHTML, nil
+	case pacta.FileType_TEXT:
+		return api.FileTypeTEXT, nil
+	case pacta.FileType_CSS:
+		return api.FileTypeCSS, nil
+	case pacta.FileType_JS:
+		return api.FileTypeJS, nil
+	case pacta.FileType_TTF:
+		return api.FileTypeTTF, nil
+	case pacta.FileType_UNKNOWN:
+		return api.FileTypeUNKNOWN, nil
 	}
-	return "", fmt.Errorf("unknown file type: %q", ft)
+	return api.FileTypeUNKNOWN, nil
 }
 
 func BlobToOAPI(b *pacta.Blob) (*api.Blob, error) {

--- a/db/sqldb/blob.go
+++ b/db/sqldb/blob.go
@@ -32,6 +32,9 @@ func (d *DB) Blob(tx db.Tx, id pacta.BlobID) (*pacta.Blob, error) {
 }
 
 func (d *DB) Blobs(tx db.Tx, ids []pacta.BlobID) (map[pacta.BlobID]*pacta.Blob, error) {
+	if len(ids) == 0 {
+		return map[pacta.BlobID]*pacta.Blob{}, nil
+	}
 	ids = dedupeIDs(ids)
 	rows, err := d.query(tx, `
 		SELECT `+blobSelectColumns+`

--- a/frontend/components/analysis/Editor.vue
+++ b/frontend/components/analysis/Editor.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import {
+  type EditorAnalysisFields as EditorFields,
+  type EditorAnalysisValues as EditorValues,
+} from '@/lib/editor'
+
+interface Props {
+  editorValues: EditorValues
+  editorFields: EditorFields
+}
+interface Emits {
+  (e: 'update:editorValues', evs: EditorValues): void
+}
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const efs = computed(() => props.editorFields)
+const evs = computed({
+  get: () => props.editorValues,
+  set: (evs) => { emit('update:editorValues', evs) },
+})
+</script>
+
+<template>
+  <div>
+    <FormEditorField
+      :editor-field="efs.name"
+      :editor-value="evs.name"
+    >
+      <PVInputText
+        v-model="evs.name.currentValue"
+      />
+    </FormEditorField>
+    <FormEditorField
+      :editor-field="efs.description"
+      :editor-value="evs.description"
+    >
+      <PVTextarea
+        v-model="evs.description.currentValue"
+        auto-resize
+      />
+    </FormEditorField>
+  </div>
+</template>

--- a/frontend/components/analysis/ListView.vue
+++ b/frontend/components/analysis/ListView.vue
@@ -125,7 +125,7 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
             icon="pi pi-external-link"
             class="p-button-outlined p-button-xs"
             :label="tt('View')"
-            :to="`${apiServerURL}/report/${slotProps.data.id}`"
+            :to="`${apiServerURL}/report/${slotProps.data.id}/`"
             new-tab
           />
         </template>

--- a/frontend/lang/en.json
+++ b/frontend/lang/en.json
@@ -26,6 +26,17 @@
     "Save Changes": "Save Changes",
     "Refresh": "Refresh"
   },
+  "components/analysis/ListView": {
+    "Created At": "Created At",
+    "Details": "Details",
+    "Name": "Name",
+    "Delete": "Delete",
+    "Metadata": "Metadata",
+    "Editable Properties": "Editable Properties",
+    "Save Changes": "Save Changes",
+    "Refresh": "Refresh",
+    "View": "View"
+  },
   "components/initiative/Toolbar": {
     "Edit": "Edit",
     "Initiative Home": "Initiative Home",
@@ -262,7 +273,8 @@
     "My Data": "My Data",
     "Portfolio Groups": "Portfolio Groups",
     "Portfolios": "Portfolios",
-    "Incomplete Uploads": "Incomplete Uploads"
+    "Incomplete Uploads": "Incomplete Uploads",
+    "Analyses": "Reports and Audits"
   },
   "pages/initiative/invitations": {
     "Yes Invitations": "This initiative requires an invitation (a unique, one-time code) to join. You can create and manage these invitations below.",

--- a/frontend/lib/editor/analysis.ts
+++ b/frontend/lib/editor/analysis.ts
@@ -1,0 +1,67 @@
+import { type Analysis } from '@/openapi/generated/pacta'
+import { Validation, type EditorFieldsFor, type EditorValuesFor, type EditorComputedValues } from './common'
+import { getEditorComputedValues, type Translation } from './utils'
+
+export type EditorAnalysisFields = EditorFieldsFor<Analysis>
+export type EditorAnalysisValues = EditorValuesFor<Analysis>
+
+const createEditorAnalysisFields = (translation: Translation): EditorAnalysisFields => {
+  const tt = (key: string) => translation.t(`lib/editor/analysis.${key}`)
+  return {
+    id: {
+      name: 'id',
+      label: tt('ID'),
+    },
+    analysisType: {
+      name: 'analysisType',
+      label: tt('Analysis Type'),
+    },
+    pactaVersion: {
+      name: 'pactaVersion',
+      label: tt('PACTA Version'),
+    },
+    portfolioSnapshot: {
+      name: 'portfolioSnapshot',
+      label: tt('Portfolio Snapshot'),
+    },
+    name: {
+      name: 'name',
+      label: tt('Name'),
+      validation: [Validation.NotEmpty],
+      helpText: tt('NameHelpText'),
+    },
+    description: {
+      name: 'description',
+      label: tt('Description'),
+      helpText: tt('DescriptionHelpText'),
+    },
+    createdAt: {
+      name: 'createdAt',
+      label: tt('Created At'),
+    },
+    ranAt: {
+      name: 'ranAt',
+      label: tt('Ran At'),
+    },
+    completedAt: {
+      name: 'completedAt',
+      label: tt('Completed At'),
+    },
+    failureCode: {
+      name: 'failureCode',
+      label: tt('Failure Code'),
+    },
+    failureMessage: {
+      name: 'failureMessage',
+      label: tt('Failure Message'),
+    },
+    artifacts: {
+      name: 'artifacts',
+      label: tt('Artifacts'),
+    },
+  }
+}
+
+export const analysisEditor = (i: Analysis, translation: Translation): EditorComputedValues<Analysis> => {
+  return getEditorComputedValues(`lib/editor/analysis[${i.id}]`, i, createEditorAnalysisFields, translation)
+}

--- a/frontend/lib/editor/index.ts
+++ b/frontend/lib/editor/index.ts
@@ -1,3 +1,4 @@
+export * from './analysis'
 export * from './common'
 export * from './incomplete_upload'
 export * from './initiative'

--- a/openapi/pacta.yaml
+++ b/openapi/pacta.yaml
@@ -1016,6 +1016,11 @@ components:
         - FileTypeZIP
         - FileTypeJSON
         - FileTypeHTML
+        - FileTypeTEXT
+        - FileTypeCSS
+        - FileTypeJS
+        - FileTypeTTF
+        - FileTypeUNKNOWN
     AnalysisType:
       type: string
       enum:

--- a/reportsrv/BUILD.bazel
+++ b/reportsrv/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//blob",
         "//db",
         "//pacta",
+        "//session",
         "@com_github_go_chi_chi_v5//:chi",
         "@org_uber_go_zap//:zap",
     ],

--- a/reportsrv/reportsrv_test.go
+++ b/reportsrv/reportsrv_test.go
@@ -2,6 +2,7 @@ package reportsrv
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,29 +12,54 @@ import (
 	"github.com/RMI/pacta/blob"
 	"github.com/RMI/pacta/db"
 	"github.com/RMI/pacta/pacta"
+	"github.com/RMI/pacta/session"
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap/zaptest"
 )
 
 func TestServeReport(t *testing.T) {
-	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
-		URLParams: chi.RouteParams{
-			Keys:   []string{"analysis_id"},
-			Values: []string{"analysis.id1"},
-		},
-	})
 
 	srv, env := setup(t)
 
+	aIDStr := "analysis.id1"
+	analysisID := pacta.AnalysisID(aIDStr)
+	ownerID := pacta.OwnerID("owner.id1")
+	userID := pacta.UserID("user.id1")
+	otherUserID := pacta.UserID("user.id2")
+	adminUserID := pacta.UserID("user.id3")
+
+	env.db.users = []*pacta.User{{
+		ID: userID,
+	}, {
+		ID: otherUserID,
+	}, {
+		ID:    adminUserID,
+		Admin: true,
+	}}
+
+	env.db.userToOwner = map[pacta.UserID]pacta.OwnerID{
+		userID:      ownerID,
+		otherUserID: "other.owner.id",
+		adminUserID: "admin.owner.id",
+	}
+
+	env.db.analyses = []*pacta.Analysis{
+		&pacta.Analysis{
+			ID:    analysisID,
+			Owner: &pacta.Owner{ID: ownerID},
+		},
+	}
+
 	env.db.analysisArtifacts = []*pacta.AnalysisArtifact{
 		&pacta.AnalysisArtifact{
-			ID:         "analysisartifact.id1",
-			AnalysisID: "analysis.id1",
-			Blob:       &pacta.Blob{ID: "blob.id1"},
+			ID:                "analysisartifact.id1",
+			AnalysisID:        analysisID,
+			Blob:              &pacta.Blob{ID: "blob.id1"},
+			AdminDebugEnabled: true,
 		},
 		&pacta.AnalysisArtifact{
 			ID:         "analysisartifact.id2",
-			AnalysisID: "analysis.id1",
+			AnalysisID: analysisID,
 			Blob:       &pacta.Blob{ID: "blob.id2"},
 		},
 	}
@@ -60,36 +86,94 @@ func TestServeReport(t *testing.T) {
 		"test://reports/1111-2222-3333-4444/lib/some/package.js": jsContent,
 	}
 
-	serveReportAndCheckResponse := func(path, contentType, responseBody string) {
-		t.Run(path, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodGet, path, nil).WithContext(ctx)
+	cases := []struct {
+		asUser          pacta.UserID
+		path            string
+		wantErr         int
+		wantContentType string
+		wantRespContent string
+	}{{
+		asUser:          userID,
+		path:            "/report/" + aIDStr,
+		wantContentType: "text/html",
+		wantRespContent: htmlContent,
+	}, {
+		asUser:          userID,
+		path:            "/report/" + aIDStr + "/",
+		wantContentType: "text/html",
+		wantRespContent: htmlContent,
+	}, {
+		asUser:          userID,
+		path:            "/report/" + aIDStr + "/index.html",
+		wantContentType: "text/html",
+		wantRespContent: htmlContent,
+	}, {
+		asUser:          userID,
+		path:            "/report/" + aIDStr + "/lib/some/package.js",
+		wantContentType: "text/javascript",
+		wantRespContent: jsContent,
+	}, {
+		asUser:          "",
+		path:            "/report/" + aIDStr,
+		wantContentType: "text/html",
+		wantErr:         http.StatusUnauthorized,
+	}, {
+		asUser:          otherUserID,
+		path:            "/report/" + aIDStr,
+		wantContentType: "text/html",
+		wantErr:         http.StatusUnauthorized,
+	}, {
+		asUser:          adminUserID,
+		path:            "/report/" + aIDStr,
+		wantContentType: "text/html",
+		wantRespContent: htmlContent,
+	}, {
+		asUser:          userID,
+		path:            "/report/a-nonsense-report",
+		wantContentType: "text/html",
+		wantErr:         http.StatusNotFound,
+	}}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+				URLParams: chi.RouteParams{
+					Keys:   []string{"analysis_id"},
+					Values: []string{"analysis.id1"},
+				},
+			})
+			if c.asUser != "" {
+				ctx = session.WithUserID(ctx, c.asUser)
+			}
+
+			r := httptest.NewRequest(http.MethodGet, c.path, nil).WithContext(ctx)
 			w := httptest.NewRecorder()
 
 			srv.serveReport(w, r)
 
 			res := w.Result()
 			// Successful response...
-			if got, want := w.Code, http.StatusOK; got != want {
-				t.Errorf("got status code %d, want %d", got, want)
+			wantCode := http.StatusOK
+			if c.wantErr != 0 {
+				wantCode = c.wantErr
+			}
+			gotCode := res.StatusCode
+			if gotCode != wantCode {
+				t.Errorf("got status code %d, want %d", gotCode, wantCode)
+			}
+			if c.wantErr != 0 {
+				return
 			}
 			// ...with the correct content-type...
-			if got, want := res.Header.Get("Content-Type"), contentType; got != want {
+			if got, want := res.Header.Get("Content-Type"), c.wantContentType; got != want {
 				t.Errorf("Content-Type = %q, want %q", got, want)
 			}
 			// ...and the correct response body.
-			if got, want := w.Body.String(), responseBody; got != want {
+			if got, want := w.Body.String(), c.wantRespContent; got != want {
 				t.Errorf("Response body = %q, want %q", got, want)
 			}
 		})
 	}
-
-	// First, request the root in a few different ways. All of then should return the /index.html file contents.
-	serveReportAndCheckResponse("/report/analysis.id1", "text/html", htmlContent)
-	serveReportAndCheckResponse("/report/analysis.id1/", "text/html", htmlContent)
-	serveReportAndCheckResponse("/report/analysis.id1/index.html", "text/html", htmlContent)
-
-	// Now, try loading an asset from the report.
-	serveReportAndCheckResponse("/report/analysis.id1/lib/some/package.js", "text/javascript", jsContent)
 }
 
 type testEnv struct {
@@ -119,10 +203,14 @@ type testDB struct {
 	// Recording inputs
 	gotAnalysisIDs []pacta.AnalysisID
 	gotBlobIDs     [][]pacta.BlobID
+	gotAuditLogs   []pacta.AuditLog
 
 	// Hardcoded outputs
+	analyses          []*pacta.Analysis
 	analysisArtifacts []*pacta.AnalysisArtifact
 	blobs             map[pacta.BlobID]*pacta.Blob
+	userToOwner       map[pacta.UserID]pacta.OwnerID
+	users             []*pacta.User
 }
 
 func (tdb *testDB) NoTxn(ctx context.Context) db.Tx {
@@ -137,6 +225,37 @@ func (tdb *testDB) AnalysisArtifactsForAnalysis(tx db.Tx, id pacta.AnalysisID) (
 func (tdb *testDB) Blobs(tx db.Tx, ids []pacta.BlobID) (map[pacta.BlobID]*pacta.Blob, error) {
 	tdb.gotBlobIDs = append(tdb.gotBlobIDs, ids)
 	return tdb.blobs, nil
+}
+
+func (tdb *testDB) GetOwnerForUser(tx db.Tx, userID pacta.UserID) (pacta.OwnerID, error) {
+	ownerID, ok := tdb.userToOwner[userID]
+	if !ok {
+		return "", fmt.Errorf("user %q not found", userID)
+	}
+	return ownerID, nil
+}
+
+func (tdb *testDB) CreateAuditLog(tx db.Tx, log *pacta.AuditLog) (pacta.AuditLogID, error) {
+	tdb.gotAuditLogs = append(tdb.gotAuditLogs, *log)
+	return pacta.AuditLogID("auditlog.id1"), nil
+}
+
+func (tdb *testDB) User(tx db.Tx, id pacta.UserID) (*pacta.User, error) {
+	for _, u := range tdb.users {
+		if u.ID == id {
+			return u, nil
+		}
+	}
+	return nil, fmt.Errorf("user %q not found", id)
+}
+
+func (tdb *testDB) Analysis(tx db.Tx, id pacta.AnalysisID) (*pacta.Analysis, error) {
+	for _, a := range tdb.analyses {
+		if a.ID == id {
+			return a, nil
+		}
+	}
+	return nil, fmt.Errorf("analysis %q not found", id)
 }
 
 type testBlob struct {


### PR DESCRIPTION
- Adds a simple FE for report display to the `my-data` page.
- Adds a `view` button which allows a user to see the report, with a few failures.
- Fixes an issue that wouldn't allow analyses to be listed appropriately (missing their artifact + blob population)
- Fixes missing `api` FileType enums
- Adds Audit Logging + Authorization Checking to the Streaming endpoint