### PR TITLE
Fix DB migration

### DIFF
--- a/cmd/tools/migratesqldb/cmd/cmd.go
+++ b/cmd/tools/migratesqldb/cmd/cmd.go
@@ -71,9 +71,10 @@ var (
 			if err != nil {
 				return fmt.Errorf("when creating the migrator: %w", err)
 			}
-			if err := migrator.Up(); err != nil {
+			if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 				return fmt.Errorf("while applying the migration(s): %w", err)
 			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
`testpgx` handled this for us before, but I forgot that `migrate.Up()` returns an `ErrNoChange` error when there's no migrations to apply, which is annoying and causes `:run_db` to fail
