### PR TITLE
Simplifies Accessing Current Properties on Editor Objects

### DIFF
--- a/frontend/components/analysis/ListView.vue
+++ b/frontend/components/analysis/ListView.vue
@@ -99,21 +99,21 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
       :value="editorObjects"
       data-key="id"
       size="small"
-      sort-field="editorValues.value.createdAt.originalValue"
+      sort-field="currentValue.value.createdAt"
       :sort-order="-1"
     >
       <PVColumn selection-mode="multiple" />
       <PVColumn
-        field="editorValues.value.createdAt.originalValue"
+        field="currentValue.value.createdAt"
         :header="tt('Created At')"
         sortable
       >
         <template #body="slotProps">
-          {{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}
+          {{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}
         </template>
       </PVColumn>
       <PVColumn
-        field="editorValues.value.name.originalValue"
+        field="currentValue.value.name"
         sortable
         :header="tt('Name')"
       />

--- a/frontend/components/incompleteupload/ListView.vue
+++ b/frontend/components/incompleteupload/ListView.vue
@@ -83,22 +83,22 @@ const saveChanges = (id: string) => {
       data-key="id"
       class="w-full"
       size="small"
-      sort-field="editorValues.value.createdAt.originalValue"
+      sort-field="currentValue.value.createdAt"
       :sort-order="-1"
     >
       <PVColumn selection-mode="multiple" />
       <PVColumn
-        field="editorValues.value.name.originalValue"
+        field="currentValue.value.name"
         sortable
         :header="tt('Name')"
       />
       <PVColumn
-        field="editorValues.value.createdAt.originalValue"
+        field="currentValue.value.createdAt"
         :header="tt('Created At')"
         sortable
       >
         <template #body="slotProps">
-          {{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}
+          {{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}
         </template>
       </PVColumn>
       <PVColumn
@@ -115,7 +115,7 @@ const saveChanges = (id: string) => {
           <div class="flex flex-column gap-2 w-fit">
             <div class="flex gap-2 justify-content-between">
               <span>Created At</span>
-              <b>{{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}</b>
+              <b>{{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}</b>
             </div>
           </div>
           <!-- TODO(grady) add failure information here. -->

--- a/frontend/components/portfolio/ListView.vue
+++ b/frontend/components/portfolio/ListView.vue
@@ -126,7 +126,7 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
       :value="editorObjects"
       data-key="id"
       size="small"
-      sort-field="editorValues.value.createdAt.originalValue"
+      sort-field="currentValue.value.createdAt"
       :sort-order="-1"
     >
       <template #empty>
@@ -136,16 +136,16 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
       </template>
       <PVColumn selection-mode="multiple" />
       <PVColumn
-        field="editorValues.value.createdAt.originalValue"
+        field="currentValue.value.createdAt"
         :header="tt('Created At')"
         sortable
       >
         <template #body="slotProps">
-          {{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}
+          {{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}
         </template>
       </PVColumn>
       <PVColumn
-        field="editorValues.value.name.originalValue"
+        field="currentValue.value.name"
         sortable
         :header="tt('Name')"
       />
@@ -155,12 +155,12 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
         <template #body="slotProps">
           <div class="flex flex-column gap-2">
             <div
-              v-if="slotProps.data.editorValues.value.groups.originalValue.length > 0"
+              v-if="slotProps.data.currentValue.value.groups.length > 0"
               class="flex gap-1 align-items-center flex-wrap"
             >
               <span>{{ tt('Groups') }}:</span>
               <LinkButton
-                v-for="membership in slotProps.data.editorValues.value.groups.originalValue"
+                v-for="membership in slotProps.data.currentValue.value.groups"
                 :key="membership.portfolioGroup.id"
                 class="p-button-outlined p-button-xs"
                 icon="pi pi-table"
@@ -169,12 +169,12 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
               />
             </div>
             <div
-              v-if="slotProps.data.editorValues.value.initiatives.originalValue.length > 0"
+              v-if="slotProps.data.currentValue.value.initiatives.length > 0"
               class="flex gap-1 align-items-center flex-wrap"
             >
               <span>{{ tt('Initiatives') }}:</span>
               <LinkButton
-                v-for="membership in slotProps.data.editorValues.value.initiatives.originalValue"
+                v-for="membership in slotProps.data.currentValue.value.initiatives"
                 :key="membership.initiative.id"
                 class="p-button-xs"
                 :label="membership.initiative.name"
@@ -200,11 +200,11 @@ const deleteSelected = () => Promise.all([selectedRows.value.map((row) => delete
           <div class="flex flex-column gap-2 w-fit">
             <div class="flex gap-2 justify-content-between">
               <span>{{ tt('Created At') }}</span>
-              <b>{{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}</b>
+              <b>{{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}</b>
             </div>
             <div class="flex gap-2 justify-content-between">
               <span>{{ tt('Number of Rows') }}</span>
-              <b>{{ slotProps.data.editorValues.value.numberOfRows.originalValue }}</b>
+              <b>{{ slotProps.data.currentValue.value.numberOfRows }}</b>
             </div>
           </div>
           <h2 class="mt-5">

--- a/frontend/components/portfolio/group/ListView.vue
+++ b/frontend/components/portfolio/group/ListView.vue
@@ -74,7 +74,7 @@ const saveChanges = (id: string) => {
   )
 }
 const editorObjectToIds = (editorObject: EditorObject): string[] => {
-  return (editorObject.editorValues.value.members.originalValue ?? []).map((m: PortfolioGroupMembershipPortfolio) => m.portfolio.id)
+  return (editorObject.currentValue.value.members ?? []).map((m: PortfolioGroupMembershipPortfolio) => m.portfolio.id)
 }
 </script>
 
@@ -102,7 +102,7 @@ const editorObjectToIds = (editorObject: EditorObject): string[] => {
       data-key="id"
       class="w-full"
       size="small"
-      sort-field="editorValues.value.createdAt.originalValue"
+      sort-field="currentValue.value.createdAt"
       :sort-order="-1"
     >
       <template #empty>
@@ -112,17 +112,17 @@ const editorObjectToIds = (editorObject: EditorObject): string[] => {
       </template>
       <PVColumn selection-mode="multiple" />
       <PVColumn
-        field="editorValues.value.name.originalValue"
+        field="currentValue.value.name"
         sortable
         :header="tt('Name')"
       />
       <PVColumn
-        field="editorValues.value.createdAt.originalValue"
+        field="currentValue.value.createdAt"
         :header="tt('Created At')"
         sortable
       >
         <template #body="slotProps">
-          {{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}
+          {{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}
         </template>
       </PVColumn>
       <PVColumn
@@ -152,7 +152,7 @@ const editorObjectToIds = (editorObject: EditorObject): string[] => {
           <div class="flex flex-column gap-2 w-fit">
             <div class="flex gap-2 justify-content-between">
               <span>Created At</span>
-              <b>{{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}</b>
+              <b>{{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}</b>
             </div>
           </div>
           <h2 class="mt-5">

--- a/frontend/pages/incomplete-uploads.vue
+++ b/frontend/pages/incomplete-uploads.vue
@@ -72,16 +72,16 @@ const deleteAll = () => withLoading(
       class="incomplete-upload-table"
     >
       <PVColumn
-        field="editorValues.value.createdAt.originalValue"
+        field="currentValue.value.createdAt"
         header="Created At"
         sortable
       >
         <template #body="slotProps">
-          {{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}
+          {{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}
         </template>
       </PVColumn>
       <PVColumn
-        field="editorValues.value.name.originalValue"
+        field="currentValue.value.name"
         sortable
         header="Name"
       />
@@ -99,23 +99,23 @@ const deleteAll = () => withLoading(
           <div class="flex flex-column gap-2 w-fit">
             <div class="flex gap-2 justify-content-between">
               <span>Created At</span>
-              <b>{{ humanReadableTimeFromStandardString(slotProps.data.editorValues.value.createdAt.originalValue).value }}</b>
+              <b>{{ humanReadableTimeFromStandardString(slotProps.data.currentValue.value.createdAt).value }}</b>
             </div>
             <div class="flex gap-2 justify-content-between">
               <span>Ran At</span>
-              <b>{{ slotProps.data.editorValues.value.ranAt.originalValue ? humanReadableTimeFromStandardString(slotProps.data.editorValues.value.ranAt.originalValue).value : 'N/A' }}</b>
+              <b>{{ slotProps.data.currentValue.value.ranAt ? humanReadableTimeFromStandardString(slotProps.data.currentValue.value.ranAt).value : 'N/A' }}</b>
             </div>
             <div class="flex gap-2 justify-content-between">
               <span>Completed At</span>
-              <b>{{ slotProps.data.editorValues.value.completedAt.originalValue ? humanReadableTimeFromStandardString(slotProps.data.editorValues.value.completedAt.originalValue).value : 'N/A' }}</b>
+              <b>{{ slotProps.data.currentValue.value.completedAt ? humanReadableTimeFromStandardString(slotProps.data.currentValue.value.completedAt).value : 'N/A' }}</b>
             </div>
             <div class="flex gap-2 justify-content-between">
               <span>Failure Code</span>
-              <b>{{ slotProps.data.editorValues.value.failureCode.originalValue ?? 'N/A' }}</b>
+              <b>{{ slotProps.data.currentValue.value.failureCode ?? 'N/A' }}</b>
             </div>
             <div class="flex gap-2 justify-content-between">
               <span>Failure Message</span>
-              <b>{{ slotProps.data.editorValues.value.failureMessage.originalValue ?? 'N/A' }}</b>
+              <b>{{ slotProps.data.currentValue.value.failureMessage ?? 'N/A' }}</b>
             </div>
             <div class="flex gap-2 justify-content-between">
               <span>ID</span>


### PR DESCRIPTION
This PR was done through a Find + Replace.

Searched for:
`editorValues.value.([^.]*).originalValue`

Replaced With:
`currentValue.value.$1`