### PR TITLE
Tear down testpgx instances

### DIFF
--- a/db/sqldb/golden/regen/humanreadableschema/humanreadableschema.go
+++ b/db/sqldb/golden/regen/humanreadableschema/humanreadableschema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/Silicon-Ally/testpgx"
 	"github.com/Silicon-Ally/testpgx/migrate"
@@ -42,5 +41,4 @@ func main() {
 		fmt.Printf(result)
 		return nil
 	})
-	os.Exit(0)
 }

--- a/db/sqldb/golden/regen/schemadump/schemadump.go
+++ b/db/sqldb/golden/regen/schemadump/schemadump.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/Silicon-Ally/testpgx"
 	"github.com/Silicon-Ally/testpgx/migrate"
@@ -42,5 +41,4 @@ func main() {
 		fmt.Printf(result)
 		return nil
 	})
-	os.Exit(0)
 }


### PR DESCRIPTION
Wondering why you have 1,000 old postgres instances hanging around in Docker? Wonder no more! We were calling `os.Exit(0)` for reasons unknown to me in these scripts, and there's a very important detail in [the documentation for os.Exit](https://pkg.go.dev/os#Exit):

> Exit causes the current program to exit with the given status code. Conventionally, code zero indicates success, non-zero an error. The program terminates immediately; **deferred functions are not run.**
