### PR TITLE
Recursive Deletes

### DIFF
--- a/cmd/server/pactasrv/initiative.go
+++ b/cmd/server/pactasrv/initiative.go
@@ -100,9 +100,12 @@ func (s *Server) DeleteInitiative(ctx context.Context, request api.DeleteInitiat
 	if err := s.initiativeDoAuthzAndAuditLog(ctx, id, pacta.AuditLogAction_Delete); err != nil {
 		return nil, err
 	}
-	err := s.DB.DeleteInitiative(s.DB.NoTxn(ctx), id)
+	buris, err := s.DB.DeleteInitiative(s.DB.NoTxn(ctx), id)
 	if err != nil {
 		return nil, oapierr.Internal("failed to delete initiative", zap.Error(err))
+	}
+	if err := s.deleteBlobs(ctx, buris...); err != nil {
+		return nil, err
 	}
 	return api.DeleteInitiative204Response{}, nil
 }

--- a/cmd/server/pactasrv/pactasrv.go
+++ b/cmd/server/pactasrv/pactasrv.go
@@ -55,7 +55,7 @@ type DB interface {
 	AllInitiatives(tx db.Tx) ([]*pacta.Initiative, error)
 	CreateInitiative(tx db.Tx, i *pacta.Initiative) error
 	UpdateInitiative(tx db.Tx, id pacta.InitiativeID, mutations ...db.UpdateInitiativeFn) error
-	DeleteInitiative(tx db.Tx, id pacta.InitiativeID) error
+	DeleteInitiative(tx db.Tx, id pacta.InitiativeID) ([]pacta.BlobURI, error)
 
 	PACTAVersion(tx db.Tx, id pacta.PACTAVersionID) (*pacta.PACTAVersion, error)
 	DefaultPACTAVersion(tx db.Tx) (*pacta.PACTAVersion, error)
@@ -108,7 +108,7 @@ type DB interface {
 	PortfolioGroups(tx db.Tx, ids []pacta.PortfolioGroupID) (map[pacta.PortfolioGroupID]*pacta.PortfolioGroup, error)
 	CreatePortfolioGroup(tx db.Tx, p *pacta.PortfolioGroup) (pacta.PortfolioGroupID, error)
 	UpdatePortfolioGroup(tx db.Tx, id pacta.PortfolioGroupID, mutations ...db.UpdatePortfolioGroupFn) error
-	DeletePortfolioGroup(tx db.Tx, id pacta.PortfolioGroupID) error
+	DeletePortfolioGroup(tx db.Tx, id pacta.PortfolioGroupID) ([]pacta.BlobURI, error)
 	CreatePortfolioGroupMembership(tx db.Tx, pgID pacta.PortfolioGroupID, pID pacta.PortfolioID) error
 	DeletePortfolioGroupMembership(tx db.Tx, pgID pacta.PortfolioGroupID, pID pacta.PortfolioID) error
 

--- a/cmd/server/pactasrv/portfolio_group.go
+++ b/cmd/server/pactasrv/portfolio_group.go
@@ -113,9 +113,12 @@ func (s *Server) DeletePortfolioGroup(ctx context.Context, request api.DeletePor
 	if err := s.portfolioGroupAuthz(ctx, id, pacta.AuditLogAction_Delete); err != nil {
 		return nil, err
 	}
-	err := s.DB.DeletePortfolioGroup(s.DB.NoTxn(ctx), id)
+	buris, err := s.DB.DeletePortfolioGroup(s.DB.NoTxn(ctx), id)
 	if err != nil {
 		return nil, oapierr.Internal("failed to delete portfolio group", zap.String("portfolio_group_id", request.Id), zap.Error(err))
+	}
+	if err := s.deleteBlobs(ctx, buris...); err != nil {
+		return nil, err
 	}
 	return api.DeletePortfolioGroup204Response{}, nil
 }

--- a/db/sqldb/initiative_test.go
+++ b/db/sqldb/initiative_test.go
@@ -87,9 +87,12 @@ func TestInitiativeCRUD(t *testing.T) {
 	}
 	assert(i)
 
-	err = tdb.DeleteInitiative(tx, i.ID)
+	buris, err := tdb.DeleteInitiative(tx, i.ID)
 	if err != nil {
 		t.Fatalf("delete initiative: %v", err)
+	}
+	if len(buris) != 0 {
+		t.Fatalf("expected no deleted buris, got %d", len(buris))
 	}
 }
 
@@ -109,9 +112,13 @@ func TestDeleteInitiative(t *testing.T) {
 	err1 := tdb.PutInitiativeUserRelationship(tx, iur)
 	noErrDuringSetup(t, err0, err1)
 
-	err := tdb.DeleteInitiative(tx, i.ID)
+	buris, err := tdb.DeleteInitiative(tx, i.ID)
 	if err != nil {
 		t.Fatalf("delete initiative: %v", err)
+	}
+
+	if len(buris) != 0 {
+		t.Fatalf("expected no buris but got %+v", buris)
 	}
 
 	_, err = tdb.Initiative(tx, i.ID)

--- a/db/sqldb/owner.go
+++ b/db/sqldb/owner.go
@@ -142,9 +142,12 @@ func (d *DB) DeleteOwner(tx db.Tx, oID pacta.OwnerID) ([]pacta.BlobURI, error) {
 			return fmt.Errorf("getting portfolio groups for owner: %w", err)
 		}
 		for _, pgroup := range pgroups {
-			err := d.DeletePortfolioGroup(tx, pgroup.ID)
+			pgBuris, err := d.DeletePortfolioGroup(tx, pgroup.ID)
 			if err != nil {
 				return fmt.Errorf("deleting portfolio group: %w", err)
+			}
+			if pgBuris != nil {
+				buris = append(buris, pgBuris...)
 			}
 		}
 		incompleteUploads, err := d.IncompleteUploadsByOwner(tx, oID)

--- a/db/sqldb/portfolio.go
+++ b/db/sqldb/portfolio.go
@@ -147,6 +147,17 @@ func (d *DB) DeletePortfolio(tx db.Tx, id pacta.PortfolioID) ([]pacta.BlobURI, e
 		if err != nil {
 			return fmt.Errorf("reading portfolio: %w", err)
 		}
+		analysisIDs, err := d.AnalysesRunOnPortfolio(tx, id)
+		if err != nil {
+			return fmt.Errorf("reading portfolio analyses: %w", err)
+		}
+		for _, aID := range analysisIDs {
+			sBuris, err := d.DeleteAnalysis(tx, aID)
+			if err != nil {
+				return fmt.Errorf("deleting analysis: %w", err)
+			}
+			buris = append(buris, sBuris...)
+		}
 		err = d.exec(tx, `DELETE FROM portfolio_group_membership WHERE portfolio_id = $1;`, id)
 		if err != nil {
 			return fmt.Errorf("deleting portfolio_group_memberships: %w", err)

--- a/db/sqldb/portfolio_group_test.go
+++ b/db/sqldb/portfolio_group_test.go
@@ -117,7 +117,7 @@ func TestPortfolioGroupCRUD(t *testing.T) {
 		CreatedAt:      time.Now(),
 	}}
 
-	err = tdb.DeletePortfolioGroup(tx, pg1.ID)
+	buris, err := tdb.DeletePortfolioGroup(tx, pg1.ID)
 	if err != nil {
 		t.Fatalf("delete portfolio group: %v", err)
 	}
@@ -127,6 +127,9 @@ func TestPortfolioGroupCRUD(t *testing.T) {
 	}
 	if diff := cmp.Diff(expecteds, actuals, portfolioGroupCmpOpts()); diff != "" {
 		t.Fatalf("portfolio group mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]pacta.BlobURI{}, buris); diff != "" {
+		t.Fatalf("blob uri mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/db/sqldb/snapshot.go
+++ b/db/sqldb/snapshot.go
@@ -46,10 +46,13 @@ func (d *DB) PortfolioSnapshot(tx db.Tx, psID pacta.PortfolioSnapshotID) (*pacta
 	return exactlyOneFromMap("portfolio_snapshot", psID, pss)
 }
 
+const snapshotQuery = `
+SELECT id, portfolio_id, portfolio_group_id, initiative_id, portfolio_ids
+FROM portfolio_snapshot
+`
+
 func (d *DB) PortfolioSnapshots(tx db.Tx, psID []pacta.PortfolioSnapshotID) (map[pacta.PortfolioSnapshotID]*pacta.PortfolioSnapshot, error) {
-	rows, err := d.query(tx, `
-		SELECT id, portfolio_id, portfolio_group_id, initiative_id, portfolio_ids
-		FROM portfolio_snapshot
+	rows, err := d.query(tx, snapshotQuery+`
 		WHERE id IN `+createWhereInFmt(len(psID))+`;`, idsToInterface(psID)...)
 	if err != nil {
 		return nil, fmt.Errorf("reading portfolio snapshot: %w", err)
@@ -63,6 +66,37 @@ func (d *DB) PortfolioSnapshots(tx db.Tx, psID []pacta.PortfolioSnapshotID) (map
 		result[ps.ID] = ps
 	}
 	return result, nil
+}
+
+const analysisLookupQuery = `
+SELECT analysis.id 
+FROM analysis 
+JOIN portfolio_snapshot
+ON analysis.portfolio_snapshot_id = portfolio_snapshot.id
+`
+
+func (d *DB) AnalysesRunOnPortfolio(tx db.Tx, pID pacta.PortfolioID) ([]pacta.AnalysisID, error) {
+	rows, err := d.query(tx, analysisLookupQuery+`WHERE portfolio_snapshot.portfolio_id = $1;`, pID)
+	if err != nil {
+		return nil, fmt.Errorf("reading portfolio snapshots by portfolio_id: %w", err)
+	}
+	return mapRowsToIDs[pacta.AnalysisID]("analyses_from_snapshot_from_portfolio", rows)
+}
+
+func (d *DB) AnalysesRunOnPortfolioGroup(tx db.Tx, pgID pacta.PortfolioGroupID) ([]pacta.AnalysisID, error) {
+	rows, err := d.query(tx, analysisLookupQuery+`WHERE portfolio_snapshot.portfolio_group_id = $1;`, pgID)
+	if err != nil {
+		return nil, fmt.Errorf("reading portfolio snapshots by portfolio_group_id: %w", err)
+	}
+	return mapRowsToIDs[pacta.AnalysisID]("analyses_from_snapshot_from_portfolio_group", rows)
+}
+
+func (d *DB) AnalysesRunOnInitiative(tx db.Tx, iID pacta.InitiativeID) ([]pacta.AnalysisID, error) {
+	rows, err := d.query(tx, analysisLookupQuery+`WHERE portfolio_snapshot.initiative_id = $1;`, iID)
+	if err != nil {
+		return nil, fmt.Errorf("reading portfolio snapshots by initiative_id: %w", err)
+	}
+	return mapRowsToIDs[pacta.AnalysisID]("analyses_from_snapshot_from_initiative", rows)
 }
 
 func (d *DB) createSnapshot(tx db.Tx, pID pacta.PortfolioID, pgID pacta.PortfolioGroupID, iID pacta.InitiativeID, portfolioIDs []pacta.PortfolioID) (pacta.PortfolioSnapshotID, error) {


### PR DESCRIPTION
- Deletes analysis based on a Portfolio if the portfolio gets deleted (satisfying the constraint we've implicitly encoded through the FKC's on the `portfolio_snapshot`'s fields).
- Does the same for `portfolio_group` and `initiative` (though we can't yet run analyses based on these)
- Because this changes the signatures to return `[]pacta.BlobURI` on deletes, adds blob deletion code to the API.

NOTE: I haven't been able to validate through running locally that the deletes for PGs or Initaitives work when this is run because we don't have the ability to run portfolio group or initaitive based analyeses yet.