### PR TITLE
Creates Access Control Section for Analyses

### DIFF
--- a/cmd/server/pactasrv/conv/pacta_to_oapi.go
+++ b/cmd/server/pactasrv/conv/pacta_to_oapi.go
@@ -395,7 +395,7 @@ func AnalysisArtifactToOAPI(aa *pacta.AnalysisArtifact) (*api.AnalysisArtifact, 
 	return &api.AnalysisArtifact{
 		Id:                string(aa.ID),
 		AdminDebugEnabled: aa.AdminDebugEnabled,
-		SharedToPublic:    aa.AdminDebugEnabled,
+		SharedToPublic:    aa.SharedToPublic,
 		Blob:              *blob,
 	}, nil
 }

--- a/frontend/components/SharedToPublicToggleButton.vue
+++ b/frontend/components/SharedToPublicToggleButton.vue
@@ -12,7 +12,7 @@ interface Emits {
 }
 const emit = defineEmits<Emits>()
 
-const prefix = 'components/AdminDebugEnabledToggleButton'
+const prefix = 'components/SharedToPublicToggleButton'
 const tt = (s: string) => t(`${prefix}.${s}`)
 const everAcked = computedBooleanLocalStorageValue(`${prefix}.everAcked`, false)
 
@@ -37,15 +37,15 @@ const noAck = () => {
   model.value = false
 }
 
-const visible = newModalVisibilityState('AdminDebugEnabledWarning')
+const visible = newModalVisibilityState('SharedToPublicWarning')
 </script>
 
 <template>
   <div>
     <ExplicitInputSwitch
       v-model:value="model"
-      :on-label="tt('Administrator Debugging Access Enabled')"
-      :off-label="tt('No Administrator Access Enabled')"
+      :on-label="tt('Shared to Public')"
+      :off-label="tt('Not Shared')"
     />
     <StandardModal
       v-model:visible="visible"
@@ -53,14 +53,12 @@ const visible = newModalVisibilityState('AdminDebugEnabledWarning')
       :sub-header="tt('ModalSubheading')"
     >
       <p>
-        {{ tt('Paragraph1' ) }}
+        {{ tt('Paragraph1') }}
       </p>
       <p>
-        {{ tt('Paragraph1' ) }}
-        You're enabling administrator access to this resource. If you do so, site administrators will be able to
-        access the content of this data.
+        {{ tt('Paragraph2') }}
       </p>
-      <div class="flex gap-2 pt-3 justify-content-between align-items-center flex-wrap">
+      <div class="flex pt-3 gap-2 justify-content-between align-items-center flex-wrap">
         <PVButton
           :label="tt('No Ack')"
           icon="pi pi-arrow-left"

--- a/frontend/components/standard/Nav.vue
+++ b/frontend/components/standard/Nav.vue
@@ -124,7 +124,7 @@ const userMenuItems = computed(() => {
         <LinkButton
           v-if="mi.to"
           :key="index"
-          :class="mi.to === router.currentRoute.value.fullPath ? 'border-noround sm:border-round' : 'p-button-text'"
+          :class="mi.to === router.currentRoute.value.path ? 'border-noround sm:border-round' : 'p-button-text'"
           :to="mi.to"
           :external="mi.external"
           :label="`${mi.label}`"
@@ -138,7 +138,7 @@ const userMenuItems = computed(() => {
         />
       </template>
       <PVButton
-        v-show="maybeMe !== undefined"
+        v-if="isAuthenticated"
         v-tooltip.left="tt('Settings')"
         icon="pi pi-user"
         class="hidden sm:flex ml-2 flex-shrink-0"

--- a/frontend/lang/en.json
+++ b/frontend/lang/en.json
@@ -58,7 +58,15 @@
     "Save Changes": "Save Changes",
     "Refresh": "Refresh",
     "View": "View",
-    "Status": "Status"
+    "Status": "Status",
+    "Access Controls": "Access Controls",
+    "Admin Debugging Enabled": "Admin Debugging",
+    "ADEHelpText": "If enabled, this analysis will be accessible to administrators for debugging purposes. When disabled, only you, the owner of this analysis, can access it.",
+    "Shared To Public": "Sharing Status",
+    "STPHelpText": "If enabled, anyone with the link can see this analysis. If disabled, folks visiting the link for this report will not be able to see it.",
+    "Audit Logs":"Audit Logs",
+    "AuditLogsHelpText": "Audit logs are a record of who has accessed or modified this analysis, and when. This is useful for debugging, for understanding who has seen this analysis, and for establishing peace of mind that your data's security is being upheld.",
+    "View Audit Logs": "View Audit Logs"
   },
   "components/initiative/Toolbar": {
     "Edit": "Edit",
@@ -164,6 +172,18 @@
     "No Administrator Access Enabled": "No Administrator Access Enabled",
     "ModalHeading": "Administrator Debugging Access",
     "ModalSubheading": "Exercise caution - this changes who can see the data that you upload",
+    "Paragraph1": "You're enabling administrator access to this resource. If you continue, site administrators will be able to access the content of this data.",
+    "Paragraph2": "Enabling this will not grant access to this data to anyone besides site administrators. Additionally, you will be able to see who accessed this data, and when, via the audit logs for this resource.",
+    "Ack": "I Understand",
+    "No Ack": "Nevermind"
+  },
+  "components/SharedToPublicToggleButton": {
+    "Shared to Public": "Shared to Public - anyone with the link can see this analysis",
+    "Not Shared": "Not Shared - only you can see this analysis",
+    "ModalHeading": "Sharing Status Change Requested",
+    "ModalSubheading": "Exercise caution - this changes who can see this report",
+    "Paragraph1": "This report is currently only visible to it's owner (you). If you set the visibility to public, then anyone with the link will be able to access it. You can change this setting at any time.",
+    "Paragraph2": "Note this is distinct from enabling administrator debugging access - if the report is not shared, but administrator debugging access is enabled, then administrators will be able to see the report, but it will not be visible to the public.",
     "Ack": "I Understand",
     "No Ack": "Nevermind"
   },

--- a/frontend/lib/auditlogquery/index.ts
+++ b/frontend/lib/auditlogquery/index.ts
@@ -150,7 +150,7 @@ const wheresQP = 'w'
 const limitQP = 'l'
 const limitDefault = 100
 const cursorQP = 'c'
-const pageURLBase = '/auditlog'
+const pageURLBase = '/audit-logs'
 
 export const urlReactiveAuditLogQuery = (fromQueryReactiveWithDefault: (key: string, defaultValue: string) => WritableComputedRef<string>): WritableComputedRef<AuditLogQueryReq> => {
   const qSorts = fromQueryReactiveWithDefault(sortsQP, '')
@@ -194,7 +194,5 @@ export const createURLAuditLogQuery = (localePath: LocalePathFunction, req: Audi
   if (qCursor) {
     q.set(cursorQP, qCursor)
   }
-  const url = new URL(pageURLBase)
-  url.search = q.toString()
-  return localePath(url.toString())
+  return localePath(pageURLBase + '?' + q.toString())
 }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -34,15 +34,8 @@ const tt = (s: string) => t(`pages/index.${s}`)
       >
         <PVImage
           preview
+          class="img-max-w-full"
           src="/img/how-it-works.jpg"
-          :pt="{
-            root: {
-              'class': 'max-w-full',
-            },
-            image : {
-              'class': 'max-w-full',
-            }
-          }"
         />
       </div>
     </div>
@@ -98,3 +91,13 @@ const tt = (s: string) => t(`pages/index.${s}`)
     </div>
   </StandardContent>
 </template>
+
+<style lang="scss">
+.img-max-w-full {
+  max-width: 100%;
+
+  img {
+    max-width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
Creates a section in the Analysis display that:
- has a toggle allowing users to bulk change ADE + STP status for all artifacts (note that individually addressable artifact sharing statuses was a SOW requirement, and that though this will definitely lead to duplicative traffic, until we have evidence it's prohibitive, we're probably OK to keep it this way
- Links to the Audit Logs for the Analysis.

Other fixes:
- Fixes a PVImage bug on the front page, the `:pt` definition had changed in the PV upgrade.
- Changes the nav to highlight as current a page if it shares the same path, even if the full-paths differ.
- Fixes an STP conversion issue.
- Fixes an Encoding issue for the audit log url.