### PR TITLE
Fix error modal handling

### DIFF
--- a/frontend/lib/error/index.ts
+++ b/frontend/lib/error/index.ts
@@ -5,6 +5,7 @@ export enum Remediation {
   Reload = 'reload',
   FileBug = 'file-bug',
   CheckUrl = 'check-url',
+  Silent = 'silent',
 }
 
 interface RemediationData {
@@ -16,6 +17,30 @@ type PACTAErrorData = RemediationData
 
 interface PACTAError extends NuxtError {
   data: PACTAErrorData
+}
+
+export const isSilent = (err: any): boolean => {
+  if (!('data' in err)) {
+    return false
+  }
+
+  if (typeof (err.data) !== 'object' || err.data === null) {
+    return false
+  }
+
+  if (!('type' in err.data) || typeof (err.data.type) !== 'string') {
+    return false
+  }
+
+  if (err.data.type !== 'remediation') {
+    return false
+  }
+
+  if (!('remediation' in err.data) || typeof (err.data.remediation) !== 'string') {
+    return false
+  }
+
+  return err.data.remediation === Remediation.Silent
 }
 
 export const createErrorWithRemediation = (err: string | Partial<NuxtError>, r: Remediation): PACTAError => {

--- a/frontend/pages/admin/merge.vue
+++ b/frontend/pages/admin/merge.vue
@@ -12,7 +12,6 @@ const fromUserId = useState<string>(`${prefix}.fromUserId`, () => '')
 const toUserId = useState<string>(`${prefix}.toUserId`, () => '')
 const done = useState<boolean>(`${prefix}.done`, () => false)
 
-// TODO(#168) An example of the error here.
 const doMerge = (): void => {
   void withLoading(() => pactaClient.mergeUsers({
     fromUserId: fromUserId.value,


### PR DESCRIPTION
As discussed, this is an alternate approach to #174 for fixing #168. It handles errors directly in `withLoading` and `pactaClient`. The problem then is that both these functions return _something_, so you still have to throw and interrupt the flow of code (I originally tried just leaving hanging promises, but our linter informed me that's a really bad idea)

Since we have to throw, we throw a sentinel so that anything further up the chain knows not to render another dialog.

I tested it in a few different cases and confirmed it does what we expect.
