### PR TITLE
Enforce the "sites" JWT claim for PACTA

### DIFF
--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -30,6 +30,8 @@ go_library(
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_lestrrat_go_jwx_v2//jwk",
         "@com_github_namsral_flag//:flag",
+        "@com_github_rmi_credential_service//allowlist",
+        "@com_github_rmi_credential_service//siteverify",
         "@com_github_rs_cors//:cors",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap_exp//zapfield",

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RMI/credential-service/allowlist"
+	"github.com/RMI/credential-service/siteverify"
 	"github.com/RMI/pacta/azure/azblob"
 	"github.com/RMI/pacta/azure/azcreds"
 	"github.com/RMI/pacta/azure/azevents"
@@ -314,6 +316,7 @@ func run(args []string) error {
 
 			chimiddleware.Recoverer,
 			jwtauth.Verifier(jwtauth.New("EdDSA", nil, jwKey)),
+			siteverify.CheckSite(allowlist.SitePACTA, *logger),
 			requireJWTIfNotPublicEndpoint,
 			session.WithAuthn(logger, db),
 		}, addl...)

--- a/deps.bzl
+++ b/deps.bzl
@@ -244,8 +244,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_benbjohnson_clock",
         importpath = "github.com/benbjohnson/clock",
-        sum = "h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=",
-        version = "v1.1.0",
+        sum = "h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=",
+        version = "v1.3.0",
     )
     go_repository(
         name = "com_github_beorn7_perks",
@@ -1559,6 +1559,12 @@ def go_dependencies():
         version = "v0.0.0-20200410134404-eec4a21b6bb0",
     )
     go_repository(
+        name = "com_github_rmi_credential_service",
+        importpath = "github.com/RMI/credential-service",
+        sum = "h1:2/5ZCoWw57TKH0P7MGy89fIr709ahbTPuU28Q0ZHWFo=",
+        version = "v0.0.0-20240710165535-63e7f8b52060",
+    )
+    go_repository(
         name = "com_github_rogpeppe_fastuuid",
         importpath = "github.com/rogpeppe/fastuuid",
         sum = "h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=",
@@ -1633,8 +1639,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_silicon_ally_zaphttplog",
         importpath = "github.com/Silicon-Ally/zaphttplog",
-        sum = "h1:XhVHdwNFJMvn1C7pSuR+FQF6nkIWgxTtEwI/1K1EE0k=",
-        version = "v0.0.0-20230719190744-b544469cb197",
+        sum = "h1:vXN2GYxnE42c5XKBQm/Zev372lNwoA3zUR6oZlh5ats=",
+        version = "v1.0.0",
     )
     go_repository(
         name = "com_github_sirupsen_logrus",
@@ -2204,8 +2210,8 @@ def go_dependencies():
     go_repository(
         name = "org_uber_go_goleak",
         importpath = "go.uber.org/goleak",
-        sum = "h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=",
-        version = "v1.1.11",
+        sum = "h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=",
+        version = "v1.2.0",
     )
     go_repository(
         name = "org_uber_go_multierr",
@@ -2216,8 +2222,8 @@ def go_dependencies():
     go_repository(
         name = "org_uber_go_zap",
         importpath = "go.uber.org/zap",
-        sum = "h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=",
-        version = "v1.24.0",
+        sum = "h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=",
+        version = "v1.25.0",
     )
     go_repository(
         name = "org_uber_go_zap_exp",

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/RMI/pacta
 
-go 1.21
+go 1.21.1
 
-toolchain go1.21.6
+toolchain go1.22.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0
@@ -12,7 +12,7 @@ require (
 	github.com/Silicon-Ally/cryptorand v1.0.1
 	github.com/Silicon-Ally/idgen v1.0.1
 	github.com/Silicon-Ally/testpgx v0.0.5
-	github.com/Silicon-Ally/zaphttplog v0.0.0-20230719190744-b544469cb197
+	github.com/Silicon-Ally/zaphttplog v1.0.0
 	github.com/bazelbuild/rules_go v0.45.0
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/dimuska139/go-email-normalizer v1.2.1
@@ -28,7 +28,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/rs/cors v1.9.0
 	github.com/spf13/cobra v1.1.3
-	go.uber.org/zap v1.24.0
+	go.uber.org/zap v1.25.0
 )
 
 require (
@@ -36,6 +36,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventgrid v0.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/RMI/credential-service v0.0.0-20240710165535-63e7f8b52060 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/RMI/credential-service v0.0.0-20240710165535-63e7f8b52060 h1:2/5ZCoWw57TKH0P7MGy89fIr709ahbTPuU28Q0ZHWFo=
+github.com/RMI/credential-service v0.0.0-20240710165535-63e7f8b52060/go.mod h1:ctXZHu60bVQQhnfwluF2J3nO5R7g0cL+xRHmigcQUQ4=
 github.com/Silicon-Ally/cryptorand v1.0.1 h1:CSZ9dYlY++GN9g/+znhk2qZevjkZ+nSlBJh2rB7jj8A=
 github.com/Silicon-Ally/cryptorand v1.0.1/go.mod h1:NxU07fWVigUzimVH2WOVanUHcjwvPA9CRpnfS7Cm3/c=
 github.com/Silicon-Ally/idgen v1.0.1 h1:O8DFr1W7jhTV5xvVrvYfYFXT8OgI4pRi6ZCO87BIC0M=
@@ -43,6 +45,7 @@ github.com/Silicon-Ally/testpgx v0.0.5 h1:wxI10yCtptIyx1XuwaJy9T34Y7sGSdU64tIoNC
 github.com/Silicon-Ally/testpgx v0.0.5/go.mod h1:nkiAcFdbY92EoeKoKiwq+BpXGfnFWnQq4lNZRy6VOBU=
 github.com/Silicon-Ally/zaphttplog v0.0.0-20230719190744-b544469cb197 h1:XhVHdwNFJMvn1C7pSuR+FQF6nkIWgxTtEwI/1K1EE0k=
 github.com/Silicon-Ally/zaphttplog v0.0.0-20230719190744-b544469cb197/go.mod h1:MOYLV+7Ug2sTUbsp4fMV1CUooTD4RFD2+eQ+Glq5wxk=
+github.com/Silicon-Ally/zaphttplog v1.0.0/go.mod h1:MOYLV+7Ug2sTUbsp4fMV1CUooTD4RFD2+eQ+Glq5wxk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -357,6 +360,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
+go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
 go.uber.org/zap/exp v0.2.0 h1:FtGenNNeCATRB3CmB/yEUnjEFeJWpB/pMcy7e2bKPYs=
 go.uber.org/zap/exp v0.2.0/go.mod h1:t0gqAIdh1MfKv9EwN/dLwfZnJxe9ITAZN78HEWPFWDQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
This is a follow-up to making the credential service support site-granular (and email-granular) ACLs, enforcing it for PACTA.
