### PR TITLE
Integrate latest report generation Docker image into site

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,10 +104,10 @@ oci_pull(
 
 oci_pull(
     name = "runner_base",
-    digest = "sha256:d0b2922dc48cb6acb7c767f89f0c92ccbe1a043166971bac0b585b3851a9b720",
-    # TODO(#44): Replace this base image with a more permanent one.
-    image = "docker.io/curfewreplica/pactatest",
-    # platforms = ["linux/amd64"],
+    # This digest is of the nightly/main tag as of 2024-07-22
+    digest = "sha256:7adec544294b5cb9e11c6bb4c43d0b2de646e5f933639f86c85f3f03c99f650e",
+    image = "ghcr.io/rmi-pacta/workflow.pacta.webapp",
+    platforms = ["linux/amd64"],
 )
 
 oci_pull(

--- a/cmd/runner/configs/local.conf
+++ b/cmd/runner/configs/local.conf
@@ -6,3 +6,6 @@ azure_topic_location centralus-1
 
 azure_storage_account rmipactalocal
 azure_report_container reports
+
+benchmark_dir /mnt/workflow-data/benchmarks/2023Q4_20240529T002355Z
+pacta_data_dir /mnt/workflow-data/pacta-data/2023Q4_20240424T120055Z

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -37,6 +37,9 @@ func run(args []string) error {
 	var (
 		env = fs.String("env", "", "The environment we're running in.")
 
+		benchmarkDir = fs.String("benchmark_dir", "", "The path to the benchmark data for report generation")
+		pactaDataDir = fs.String("pacta_data_dir", "", "The path to the PACTA data for report generation")
+
 		azEventTopic    = fs.String("azure_event_topic", "", "The EventGrid topic to send notifications when tasks have finished")
 		azTopicLocation = fs.String("azure_topic_location", "", "The location (like 'centralus-1') where our EventGrid topics are hosted")
 
@@ -80,9 +83,11 @@ func run(args []string) error {
 	}
 
 	h, err := async.New(&async.Config{
-		Blob:   blobClient,
-		PubSub: pubsubClient,
-		Logger: logger,
+		Blob:         blobClient,
+		PubSub:       pubsubClient,
+		Logger:       logger,
+		BenchmarkDir: *benchmarkDir,
+		PACTADataDir: *pactaDataDir,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to init async biz logic handler: %w", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -73,6 +73,7 @@ func run(args []string) error {
 		localDockerTenantID     = fs.String("local_docker_tenant_id", "", "The Azure Tenant ID the localdocker service principal lives in")
 		localDockerClientID     = fs.String("local_docker_client_id", "", "The client ID of the localdocker service principal")
 		localDockerClientSecret = fs.String("local_docker_client_secret", "", "The client secret for accessing the localdocker service principal")
+		dockerRepoRoot          = fs.String("docker_repo_root", "", "Absolute path to the repo, used for finding the ./workflow-data directory for the runner")
 
 		// PACTA Execution
 		useAZRunner = fs.Bool("use_azure_runner", false, "If true, execute PACTA on Azure Container Apps Jobs instead of a local instance.")
@@ -220,7 +221,7 @@ func run(args []string) error {
 			TenantID:     *localDockerTenantID,
 			ClientID:     *localDockerClientID,
 			ClientSecret: *localDockerClientSecret,
-		})
+		}, *dockerRepoRoot)
 		if err != nil {
 			return fmt.Errorf("failed to init docker runner: %w", err)
 		}

--- a/db/sqldb/golden/human_readable_schema.sql
+++ b/db/sqldb/golden/human_readable_schema.sql
@@ -52,7 +52,15 @@ CREATE TYPE file_type AS ENUM (
     'css',
     'js',
     'ttf',
-    'unknown');
+    'unknown',
+    'js.map',
+    'woff',
+    'woff2',
+    'eot',
+    'svg',
+    'png',
+    'jpg',
+    'pdf');
 CREATE TYPE language AS ENUM (
     'en',
     'de',

--- a/db/sqldb/golden/schema_dump.sql
+++ b/db/sqldb/golden/schema_dump.sql
@@ -135,7 +135,15 @@ CREATE TYPE public.file_type AS ENUM (
     'css',
     'js',
     'ttf',
-    'unknown'
+    'unknown',
+    'js.map',
+    'woff',
+    'woff2',
+    'eot',
+    'svg',
+    'png',
+    'jpg',
+    'pdf'
 );
 
 

--- a/db/sqldb/migrations/0014_add_more_report_file_types.down.sql
+++ b/db/sqldb/migrations/0014_add_more_report_file_types.down.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- There isn't a way to delete a value from an enum, so this is the workaround
+-- https://stackoverflow.com/a/56777227/17909149
+
+ALTER TABLE blob ALTER file_type TYPE TEXT;
+
+DROP TYPE file_type;
+CREATE TYPE file_type AS ENUM (
+    'csv',
+    'yaml',
+    'zip',
+    'html',
+    'json',
+    'txt',
+    'css',
+    'js',
+    'ttf',
+    'unknown');
+
+ALTER TABLE blob
+    ALTER file_type TYPE file_type
+        USING file_type::file_type;
+
+COMMIT;

--- a/db/sqldb/migrations/0014_add_more_report_file_types.up.sql
+++ b/db/sqldb/migrations/0014_add_more_report_file_types.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TYPE file_type ADD VALUE 'js.map';
+ALTER TYPE file_type ADD VALUE 'woff';
+ALTER TYPE file_type ADD VALUE 'woff2';
+ALTER TYPE file_type ADD VALUE 'eot';
+ALTER TYPE file_type ADD VALUE 'svg';
+ALTER TYPE file_type ADD VALUE 'png';
+ALTER TYPE file_type ADD VALUE 'jpg';
+ALTER TYPE file_type ADD VALUE 'pdf';
+
+COMMIT;

--- a/db/sqldb/sqldb_test.go
+++ b/db/sqldb/sqldb_test.go
@@ -95,6 +95,7 @@ func TestSchemaHistory(t *testing.T) {
 		{ID: 11, Version: 11}, // 0011_add_report_file_types
 		{ID: 12, Version: 12}, // 0012_portfolio_properties
 		{ID: 13, Version: 13}, // 0013_user_search
+		{ID: 14, Version: 14}, // 0014_add_more_report_file_types
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/pacta/pacta.go
+++ b/pacta/pacta.go
@@ -208,10 +208,19 @@ const (
 	FileType_JSON = "json"
 
 	// All for serving reports
-	FileType_TEXT    = "txt"
-	FileType_CSS     = "css"
-	FileType_JS      = "js"
-	FileType_TTF     = "ttf"
+	FileType_TEXT   = "txt"
+	FileType_CSS    = "css"
+	FileType_JS     = "js"
+	FileType_JS_MAP = "js.map"
+	FileType_TTF    = "ttf"
+	FileType_WOFF   = "woff"
+	FileType_WOFF2  = "woff2"
+	FileType_EOT    = "eot"
+	FileType_SVG    = "svg"
+	FileType_PNG    = "png"
+	FileType_JPG    = "jpg"
+	FileType_PDF    = "pdf"
+
 	FileType_UNKNOWN = "unknown"
 )
 
@@ -225,7 +234,15 @@ var FileTypeValues = []FileType{
 	FileType_TEXT,
 	FileType_CSS,
 	FileType_JS,
+	FileType_JS_MAP,
 	FileType_TTF,
+	FileType_WOFF,
+	FileType_WOFF2,
+	FileType_EOT,
+	FileType_SVG,
+	FileType_PNG,
+	FileType_JPG,
+	FileType_PDF,
 	FileType_UNKNOWN,
 }
 
@@ -251,8 +268,24 @@ func ParseFileType(s string) (FileType, error) {
 		return FileType_CSS, nil
 	case "js":
 		return FileType_JS, nil
+	case "js.map":
+		return FileType_JS_MAP, nil
 	case "ttf":
 		return FileType_TTF, nil
+	case "woff":
+		return FileType_WOFF, nil
+	case "woff2":
+		return FileType_WOFF2, nil
+	case "eot":
+		return FileType_EOT, nil
+	case "svg":
+		return FileType_SVG, nil
+	case "png":
+		return FileType_PNG, nil
+	case "jpg":
+		return FileType_JPG, nil
+	case "pdf":
+		return FileType_PDF, nil
 	case "unknown":
 		return FileType_UNKNOWN, nil
 	}

--- a/reportsrv/reportsrv.go
+++ b/reportsrv/reportsrv.go
@@ -133,6 +133,7 @@ func (s *Server) serveReport(w http.ResponseWriter, r *http.Request) {
 	if subPath == "" {
 		subPath = "index.html"
 	}
+	subPath = "report-output/report/" + subPath
 
 	for _, aa := range artifacts {
 		// Container is just 'reports', we can ignore that.

--- a/reportsrv/reportsrv_test.go
+++ b/reportsrv/reportsrv_test.go
@@ -69,13 +69,13 @@ func TestServeReport(t *testing.T) {
 	env.db.blobs = map[pacta.BlobID]*pacta.Blob{
 		"blob.id1": &pacta.Blob{
 			ID:       "blob.id1",
-			BlobURI:  "test://reports/1111-2222-3333-4444/index.html",
+			BlobURI:  "test://reports/1111-2222-3333-4444/report-output/report/index.html",
 			FileType: pacta.FileType_HTML,
 			FileName: "index.html",
 		},
 		"blob.id2": &pacta.Blob{
 			ID:       "blob.id2",
-			BlobURI:  "test://reports/1111-2222-3333-4444/lib/some/package.js",
+			BlobURI:  "test://reports/1111-2222-3333-4444/report-output/report/lib/some/package.js",
 			FileType: pacta.FileType_JS,
 			FileName: "package.js",
 		},
@@ -84,8 +84,8 @@ func TestServeReport(t *testing.T) {
 	htmlContent := "<html>this is the index</html>"
 	jsContent := "function() { return 'some js' }"
 	env.blob.blobContents = map[string]string{
-		"test://reports/1111-2222-3333-4444/index.html":          htmlContent,
-		"test://reports/1111-2222-3333-4444/lib/some/package.js": jsContent,
+		"test://reports/1111-2222-3333-4444/report-output/report/index.html":          htmlContent,
+		"test://reports/1111-2222-3333-4444/report-output/report/lib/some/package.js": jsContent,
 	}
 
 	standardPath := "/report/" + aIDStr + "/"

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -134,6 +134,7 @@ LOCAL_DSN+=" sslmode=disable"
 FLAGS+=(
   "--config=${ROOT}/cmd/server/configs/local.conf"
   "--local_dsn=${LOCAL_DSN}"
+  "--docker_repo_root=${ROOT}"
 )
 
 if [[ ! -z "$EG_SUB_NAME" ]]; then


### PR DESCRIPTION
This PR updates the async task runner to support the new base image (which comes from [1]).

This includes things like:
- Uploading the new output directories (summaries + analysis)
- Fixing report paths so we can render the new reports
- Adding support for the new file types that show up in these new reports
- Supporting the new input formats (the benchmark + pacta-data dirs, input JSON, env vars, etc)

Importantly, this makes the new create-report image work **locally**, but doesn't do the Azure bits. That'll come in the next PR.

[1] https://github.com/rmi-pacta/workflow.pacta.webapp/pkgs/container/workflow.pacta.webapp
