### PR TITLE
Pull LFS files in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Cache Bazel
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazel
@@ -20,7 +20,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bazel-
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Azure CLI login
         uses: azure/login@v1
@@ -33,7 +35,7 @@ jobs:
       - name: Login to ACR via OIDC
         run: az acr login --name rmisa
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
This is a fix for #209

The gist is that we host the sample CSV, e.g. at https://pacta.dev.rmi.siliconally.dev/samples/sample-1.csv

Currently, on dev, that file contains:

```
version https://git-lfs.github.com/spec/v1
oid sha256:abdb709396bff1337709b6eb7bc26cde547615d88a619f5c9846fde1fb585335
size 131685
```

Which is just the LFS pointer to the actual file. This PR enables downloading LFS files when the GH Actions run checks out the repo

It also updates the version for other actions we use in the workflow
