### PR TITLE
Update runner base image + tweaks to support it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           containerAppEnvironment: pacta-test
           resourceGroup: RMI-SP-PACTA-WEU-PAT-DEV
           imageToDeploy: rmisppactaweupatdev.azurecr.io/pacta:test
-          location: centralus
+          location: westeurope
 
       - name: Deploy frontend
         uses: Azure/static-web-apps-deploy@v1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,8 +104,8 @@ oci_pull(
 
 oci_pull(
     name = "runner_base",
-    # This digest is of the nightly/main tag as of 2024-07-22
-    digest = "sha256:7adec544294b5cb9e11c6bb4c43d0b2de646e5f933639f86c85f3f03c99f650e",
+    # This digest is of the nightly/main tag as of 2024-12-06
+    digest = "sha256:35c8eaac721350ca6ef3bfb3e6080c5412ddb9061299c62bb4fd2fc6df8d0227",
     image = "ghcr.io/rmi-pacta/workflow.pacta.webapp",
     platforms = ["linux/amd64"],
 )

--- a/async/async.go
+++ b/async/async.go
@@ -241,9 +241,9 @@ type ReportInput struct {
 }
 
 type ReportInputPortfolio struct {
-	Files        string `json:"files"`
-	HoldingsDate string `json:"holdingsDate"`
-	Name         string `json:"name"`
+	Files        []string `json:"files"`
+	HoldingsDate string   `json:"holdingsDate"`
+	Name         string   `json:"name"`
 }
 
 type ReportEnv struct {
@@ -378,7 +378,7 @@ func (h *Handler) CreateReport(ctx context.Context, taskID task.ID, req *task.Cr
 
 	inp := ReportInput{
 		Portfolio: ReportInputPortfolio{
-			Files:        fileNameWithExt,
+			Files:        []string{fileNameWithExt},
 			HoldingsDate: "2023-12-31",   // TODO(#206)
 			Name:         "FooPortfolio", // TODO(#206)
 		},
@@ -499,7 +499,7 @@ func (h *Handler) uploadDirectory(ctx context.Context, dirPath, container string
 		// Returns pacta.FileType_UNKNOWN for unrecognized extensions, which we'll serve as binary blobs.
 		ft := fileTypeFromFilename(fn)
 		if ft == pacta.FileType_UNKNOWN {
-			h.logger.Error("unhandled file extension", zap.String("dir", dirPath), zap.String("file_ext", filepath.Ext(fn)))
+			h.logger.Error("unhandled file extension", zap.String("dir", dirPath), zap.String("filename", fn), zap.String("file_ext", filepath.Ext(fn)))
 		}
 		artifacts = append(artifacts, &task.AnalysisArtifact{
 			BlobURI:  pacta.BlobURI(uri),
@@ -538,6 +538,8 @@ func fileTypeFromFilename(fn string) pacta.FileType {
 		switch ext2 := filepath.Ext(strings.TrimSuffix(fn, ext)); ext2 {
 		case ".js":
 			return pacta.FileType_JS_MAP
+		case ".css":
+			return pacta.FileType_CSS_MAP
 		default:
 			return pacta.FileType_UNKNOWN
 		}
@@ -556,7 +558,11 @@ func fileTypeFromFilename(fn string) pacta.FileType {
 	case ".jpg":
 		return pacta.FileType_JPG
 	case ".pdf":
-		return pacta.FileType_TTF
+		return pacta.FileType_PDF
+	case ".xlsx":
+		return pacta.FileType_XLSX
+	case ".rds":
+		return pacta.FileType_RDS
 	default:
 		return pacta.FileType_UNKNOWN
 	}

--- a/azure/aztask/aztask.go
+++ b/azure/aztask/aztask.go
@@ -87,10 +87,10 @@ func (r *Runner) Run(ctx context.Context, cfg *task.Config) (task.RunnerID, erro
 				Command: toPtrs(cfg.Command),
 				Env:     envVars,
 				Image:   to.Ptr(cfg.Image.String()),
-				Name:    to.Ptr("pacta-runner"),
+				Name:    to.Ptr(r.cfg.JobName),
 				Resources: &armappcontainers.ContainerResources{
-					CPU:    to.Ptr(1.0),
-					Memory: to.Ptr("2Gi"),
+					CPU:    to.Ptr(4.0),
+					Memory: to.Ptr("16Gi"),
 				},
 			}},
 		},

--- a/cmd/parser/configs/test.conf
+++ b/cmd/parser/configs/test.conf
@@ -2,7 +2,7 @@ env test
 min_log_level warn
 
 azure_event_topic pacta-events-test
-azure_topic_location centralus-1
+azure_topic_location westeurope-1
 
 azure_storage_account rmipactatest
 azure_dest_portfolio_container parsedportfolios

--- a/cmd/parser/main.go
+++ b/cmd/parser/main.go
@@ -46,6 +46,10 @@ func run(args []string) error {
 		azStorageAccount         = fs.String("azure_storage_account", "", "The storage account to authenticate against for blob operations")
 		azDestPortfolioContainer = fs.String("azure_dest_portfolio_container", "", "The container in the storage account where we write parsed portfolios")
 
+		// TODO(brandon): Pretty sure these aren't needed, but it's a larger refactoring to split parsing logic from report generation logic.
+		benchmarkDir = fs.String("benchmark_dir", "", "The path to the benchmark data for report generation")
+		pactaDataDir = fs.String("pacta_data_dir", "", "The path to the PACTA data for report generation")
+
 		minLogLevel zapcore.Level = zapcore.DebugLevel
 	)
 	fs.Var(&minLogLevel, "min_log_level", "If set, retains logs at the given level and above. Options: 'debug', 'info', 'warn', 'error', 'dpanic', 'panic', 'fatal' - default warn.")
@@ -103,6 +107,10 @@ func run(args []string) error {
 		Blob:   blobClient,
 		PubSub: pubsubClient,
 		Logger: logger,
+
+		// TODO(brandon): Pretty sure these aren't needed, but it's a larger refactoring to split parsing logic from report generation logic.
+		BenchmarkDir: *benchmarkDir,
+		PACTADataDir: *pactaDataDir,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to init async biz logic handler: %w", err)

--- a/cmd/runner/configs/test.conf
+++ b/cmd/runner/configs/test.conf
@@ -2,7 +2,7 @@ env test
 min_log_level warn
 
 azure_event_topic pacta-events-test
-azure_topic_location centralus-1
+azure_topic_location westeurope-1
 
 azure_storage_account rmipactatest
 azure_report_container reports

--- a/db/sqldb/golden/human_readable_schema.sql
+++ b/db/sqldb/golden/human_readable_schema.sql
@@ -60,7 +60,10 @@ CREATE TYPE file_type AS ENUM (
     'svg',
     'png',
     'jpg',
-    'pdf');
+    'pdf',
+    'xlsx',
+    'rds',
+    'css.map');
 CREATE TYPE language AS ENUM (
     'en',
     'de',

--- a/db/sqldb/golden/schema_dump.sql
+++ b/db/sqldb/golden/schema_dump.sql
@@ -143,7 +143,10 @@ CREATE TYPE public.file_type AS ENUM (
     'svg',
     'png',
     'jpg',
-    'pdf'
+    'pdf',
+    'xlsx',
+    'rds',
+    'css.map'
 );
 
 

--- a/db/sqldb/migrations/0015_add_more_report_file_types.down.sql
+++ b/db/sqldb/migrations/0015_add_more_report_file_types.down.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- There isn't a way to delete a value from an enum, so this is the workaround
+-- https://stackoverflow.com/a/56777227/17909149
+
+ALTER TABLE blob ALTER file_type TYPE TEXT;
+
+DROP TYPE file_type;
+CREATE TYPE file_type AS ENUM (
+    'csv',
+    'yaml',
+    'zip',
+    'html',
+    'json',
+    'txt',
+    'css',
+    'js',
+    'ttf',
+    'unknown',
+    'js.map',
+    'woff',
+    'woff2',
+    'eot',
+    'svg',
+    'png',
+    'jpg',
+    'pdf'
+);
+
+ALTER TABLE blob
+    ALTER file_type TYPE file_type
+        USING file_type::file_type;
+
+COMMIT;

--- a/db/sqldb/migrations/0015_add_more_report_file_types.up.sql
+++ b/db/sqldb/migrations/0015_add_more_report_file_types.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TYPE file_type ADD VALUE 'xlsx';
+ALTER TYPE file_type ADD VALUE 'rds';
+ALTER TYPE file_type ADD VALUE 'css.map';
+
+COMMIT;

--- a/db/sqldb/sqldb_test.go
+++ b/db/sqldb/sqldb_test.go
@@ -96,6 +96,7 @@ func TestSchemaHistory(t *testing.T) {
 		{ID: 12, Version: 12}, // 0012_portfolio_properties
 		{ID: 13, Version: 13}, // 0013_user_search
 		{ID: 14, Version: 14}, // 0014_add_more_report_file_types
+		{ID: 15, Version: 15}, // 0015_add_more_report_file_types
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/pacta/pacta.go
+++ b/pacta/pacta.go
@@ -208,18 +208,21 @@ const (
 	FileType_JSON = "json"
 
 	// All for serving reports
-	FileType_TEXT   = "txt"
-	FileType_CSS    = "css"
-	FileType_JS     = "js"
-	FileType_JS_MAP = "js.map"
-	FileType_TTF    = "ttf"
-	FileType_WOFF   = "woff"
-	FileType_WOFF2  = "woff2"
-	FileType_EOT    = "eot"
-	FileType_SVG    = "svg"
-	FileType_PNG    = "png"
-	FileType_JPG    = "jpg"
-	FileType_PDF    = "pdf"
+	FileType_TEXT    = "txt"
+	FileType_CSS     = "css"
+	FileType_CSS_MAP = "css.map"
+	FileType_JS      = "js"
+	FileType_JS_MAP  = "js.map"
+	FileType_TTF     = "ttf"
+	FileType_WOFF    = "woff"
+	FileType_WOFF2   = "woff2"
+	FileType_EOT     = "eot"
+	FileType_SVG     = "svg"
+	FileType_PNG     = "png"
+	FileType_JPG     = "jpg"
+	FileType_PDF     = "pdf"
+	FileType_XLSX    = "xlsx"
+	FileType_RDS     = "rds"
 
 	FileType_UNKNOWN = "unknown"
 )
@@ -243,6 +246,7 @@ var FileTypeValues = []FileType{
 	FileType_PNG,
 	FileType_JPG,
 	FileType_PDF,
+	FileType_XLSX,
 	FileType_UNKNOWN,
 }
 
@@ -266,6 +270,8 @@ func ParseFileType(s string) (FileType, error) {
 		return FileType_TEXT, nil
 	case "css":
 		return FileType_CSS, nil
+	case "css.map":
+		return FileType_CSS_MAP, nil
 	case "js":
 		return FileType_JS, nil
 	case "js.map":
@@ -286,6 +292,10 @@ func ParseFileType(s string) (FileType, error) {
 		return FileType_JPG, nil
 	case "pdf":
 		return FileType_PDF, nil
+	case "xlsx":
+		return FileType_XLSX, nil
+	case "rds":
+		return FileType_RDS, nil
 	case "unknown":
 		return FileType_UNKNOWN, nil
 	}

--- a/taskrunner/taskrunner.go
+++ b/taskrunner/taskrunner.go
@@ -123,6 +123,15 @@ func (tr *TaskRunner) ParsePortfolio(ctx context.Context, req *task.ParsePortfol
 			Key:   "PARSE_PORTFOLIO_REQUEST",
 			Value: value,
 		},
+		// TODO(brandon): Unhardcode these
+		{
+			Key:   "BENCHMARK_DIR",
+			Value: "/mnt/benchmark-data/65c1a416721b22a98c7925999ae03bc4",
+		},
+		{
+			Key:   "PACTA_DATA_DIR",
+			Value: "/mnt/pacta-data/2023Q4_20240718T150252Z",
+		},
 	})
 }
 
@@ -156,6 +165,15 @@ func (tr *TaskRunner) CreateReport(ctx context.Context, req *task.CreateReportRe
 		{
 			Key:   "CREATE_REPORT_REQUEST",
 			Value: value,
+		},
+		// TODO(brandon): Unhardcode these
+		{
+			Key:   "BENCHMARK_DIR",
+			Value: "/mnt/benchmark-data/65c1a416721b22a98c7925999ae03bc4",
+		},
+		{
+			Key:   "PACTA_DATA_DIR",
+			Value: "/mnt/pacta-data/2023Q4_20240718T150252Z",
 		},
 	})
 }


### PR DESCRIPTION
This PR updates the runner base image to fix something I noticed in an Azure run that the RMI folk have since fixed.

There have been some small format tweaks in the mean time:
- More file types outputted by the report generation flow
- `Files` is now an array of strings
