### PR TITLE
Add support for audits

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,8 +104,8 @@ oci_pull(
 
 oci_pull(
     name = "runner_base",
-    # This digest is of the nightly/main tag as of 2024-12-06
-    digest = "sha256:35c8eaac721350ca6ef3bfb3e6080c5412ddb9061299c62bb4fd2fc6df8d0227",
+    # This digest is of the nightly/main tag as of 2024-12-28
+    digest = "sha256:b1bcfaf52c418faabcd6b6fcbbec0f27f543a10b4a9384d75811d03dbba0d4d7",
     image = "ghcr.io/rmi-pacta/workflow.pacta.webapp",
     platforms = ["linux/amd64"],
 )

--- a/cmd/runner/configs/dev.conf
+++ b/cmd/runner/configs/dev.conf
@@ -6,3 +6,4 @@ azure_topic_location centralus-1
 
 azure_storage_account rmipactadev
 azure_report_container reports
+azure_audit_container audits

--- a/cmd/runner/configs/local.conf
+++ b/cmd/runner/configs/local.conf
@@ -6,6 +6,7 @@ azure_topic_location centralus-1
 
 azure_storage_account rmipactalocal
 azure_report_container reports
+azure_audit_container audits
 
 benchmark_dir /mnt/workflow-data/benchmarks/2023Q4_20240529T002355Z
 pacta_data_dir /mnt/workflow-data/pacta-data/2023Q4_20240424T120055Z

--- a/cmd/runner/configs/test.conf
+++ b/cmd/runner/configs/test.conf
@@ -6,3 +6,4 @@ azure_topic_location westeurope-1
 
 azure_storage_account rmipactatest
 azure_report_container reports
+azure_audit_container audits

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -45,6 +45,7 @@ func run(args []string) error {
 
 		azStorageAccount  = fs.String("azure_storage_account", "", "The storage account to authenticate against for blob operations")
 		azReportContainer = fs.String("azure_report_container", "", "The container in the storage account where we write generated portfolio reports to")
+		azAuditContainer  = fs.String("azure_audit_container", "", "The container in the storage account where we write generated portfolio audits to")
 
 		minLogLevel zapcore.Level = zapcore.DebugLevel
 	)
@@ -97,7 +98,9 @@ func run(args []string) error {
 		task.CreateReport: toRunFn(async.LoadCreateReportRequestFromEnv, func(ctx context.Context, id task.ID, req *task.CreateReportRequest) error {
 			return h.CreateReport(ctx, id, req, *azReportContainer)
 		}),
-		task.CreateAudit: toRunFn(async.LoadCreateAuditRequestFromEnv, h.CreateAudit),
+		task.CreateAudit: toRunFn(async.LoadCreateAuditRequestFromEnv, func(ctx context.Context, id task.ID, req *task.CreateAuditRequest) error {
+			return h.CreateAudit(ctx, id, req, *azAuditContainer)
+		}),
 	}
 
 	taskID := task.ID(os.Getenv("TASK_ID"))

--- a/frontend/components/analysis/AccessButtons.vue
+++ b/frontend/components/analysis/AccessButtons.vue
@@ -43,7 +43,7 @@ const downloadInProgress = useState<boolean>(`${statePrefix}.downloadInProgress`
 const doDownload = async () => {
   downloadInProgress.value = true
   // Just download the audit_file.csv for audits
-  const artifactsToDownload = props.analysis.analysisType === AnalysisType.ANALYSIS_TYPE_AUDIT ? props.analysis.artifacts.filter((a) => a.blob.fileName === 'audit_file.csv') : props.analysis.artifacts;
+  const artifactsToDownload = props.analysis.analysisType === AnalysisType.ANALYSIS_TYPE_AUDIT ? props.analysis.artifacts.filter((a) => a.blob.fileName === 'audit_file.csv') : props.analysis.artifacts
   const response: AccessBlobContentResp = await pactaClient.accessBlobContent({
     items: artifactsToDownload.map((asset): AccessBlobContentReqItem => ({
       blobId: asset.blob.id,
@@ -53,9 +53,9 @@ const doDownload = async () => {
   let content: Blob | null = null
   let fileName: string | null = null
   if (response.items.length === 1) {
-      const resp = await fetch(response.items[0].downloadUrl)
-      content = await resp.blob()
-      fileName = artifactsToDownload[0].blob.fileName
+    const resp = await fetch(response.items[0].downloadUrl)
+    content = await resp.blob()
+    fileName = artifactsToDownload[0].blob.fileName
   } else {
     const zip = new JSZip()
     await Promise.all(response.items.map(
@@ -101,8 +101,8 @@ const openReport = () => navigateTo(`${apiServerURL}/report/${props.analysis.id}
       @click="openReport"
     />
     <PVButton
-      v-tooltip="canAccess ? tt('Download') : ''"
       v-if="isCompleted"
+      v-tooltip="canAccess ? tt('Download') : ''"
       :disabled="downloadInProgress || !canAccess"
       :loading="downloadInProgress"
       :icon="downloadInProgress ? 'pi pi-spinner pi-spin' : 'pi pi-download'"

--- a/frontend/components/analysis/AccessButtons.vue
+++ b/frontend/components/analysis/AccessButtons.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Analysis, type AccessBlobContentReqItem, type AccessBlobContentResp } from '@/openapi/generated/pacta'
+import { type Analysis, type AccessBlobContentReqItem, type AccessBlobContentResp, AnalysisType } from '@/openapi/generated/pacta'
 import JSZip from 'jszip'
 
 const { t } = useI18n()
@@ -32,6 +32,12 @@ const canAccessAsOwner = computed(() => {
 })
 const canAccess = computed(() => {
   return canAccessAsPublic.value || canAccessAsAdmin.value || canAccessAsOwner.value
+})
+const isCompleted = computed(() => {
+  return props.analysis.completedAt !== undefined && props.analysis.failureMessage === undefined
+})
+const isViewable = computed(() => {
+  return isCompleted.value && (props.analysis.analysisType === AnalysisType.ANALYSIS_TYPE_DASHBOARD || props.analysis.analysisType === AnalysisType.ANALYSIS_TYPE_REPORT)
 })
 const downloadInProgress = useState<boolean>(`${statePrefix}.downloadInProgress`, () => false)
 const doDownload = async () => {
@@ -76,6 +82,7 @@ const openReport = () => navigateTo(`${apiServerURL}/report/${props.analysis.id}
     class="flex gap-1 align-items-center w-fit"
   >
     <PVButton
+      v-if="isViewable"
       icon="pi pi-external-link"
       :disabled="!canAccess"
       class="p-button-secondary p-button-outlined p-button-xs"
@@ -84,6 +91,7 @@ const openReport = () => navigateTo(`${apiServerURL}/report/${props.analysis.id}
     />
     <PVButton
       v-tooltip="canAccess ? tt('Download') : ''"
+      v-if="isCompleted"
       :disabled="downloadInProgress || !canAccess"
       :loading="downloadInProgress"
       :icon="downloadInProgress ? 'pi pi-spinner pi-spin' : 'pi pi-download'"

--- a/frontend/components/portfolio/ListView.vue
+++ b/frontend/components/portfolio/ListView.vue
@@ -377,6 +377,13 @@ const auditLogURL = (id: string) => {
                       {{ slotProps.data.analyses.filter((a: Analysis) => a.analysisType === AnalysisType.ANALYSIS_TYPE_AUDIT).length }}
                       {{ tt('Audits') }}
                     </PVInlineMessage>
+                    <PVInlineMessage
+                      severity="success"
+                      icon="pi pi-copy"
+                    >
+                      {{ slotProps.data.analyses.filter((a: Analysis) => a.analysisType === AnalysisType.ANALYSIS_TYPE_DASHBOARD).length }}
+                      {{ tt('Dashboards') }}
+                    </PVInlineMessage>
                   </div>
                 </CommonAccordionHeader>
               </template>

--- a/frontend/lang/en.json
+++ b/frontend/lang/en.json
@@ -208,6 +208,7 @@
     "Details": "Details",
     "Groups": "Groups",
     "Reports": "Reports",
+    "Dashboards": "Dashboards",
     "Discard Changes": "Discard Changes",
     "InitiativesHelpText": "Initiatives allow you to contribute your data for bulk analysis as part of a regulatory or other project. Adding a portfolio to an initiative enables the initiative owner to run analysis over your data as part of bulk runs, and enables them to download your data.",
     "Audits": "Audits",

--- a/frontend/lang/en.json
+++ b/frontend/lang/en.json
@@ -259,6 +259,7 @@
   },
   "components/analysis/RunButton": {
     "Run": "Run",
+    "Running": "Running",
     "AnalysisTypeAUDIT": "Audit",
     "AnalysisTypeREPORT": "Report",
     "AnalysisTypeDASHBOARD": "Dashboard (Beta)",

--- a/taskrunner/taskrunner.go
+++ b/taskrunner/taskrunner.go
@@ -157,6 +157,15 @@ func (tr *TaskRunner) CreateAudit(ctx context.Context, req *task.CreateAuditRequ
 			Key:   "CREATE_AUDIT_REQUEST",
 			Value: value,
 		},
+		// TODO(brandon): Unhardcode these
+		{
+			Key:   "BENCHMARK_DIR",
+			Value: "/mnt/benchmark-data/65c1a416721b22a98c7925999ae03bc4",
+		},
+		{
+			Key:   "PACTA_DATA_DIR",
+			Value: "/mnt/pacta-data/2023Q4_20240718T150252Z",
+		},
 	})
 }
 


### PR DESCRIPTION
This PR adds all the stuff needed for running audits:
- Updating the `runner_base` image to the newest version
- Interfacing with the `run_audit.sh` script
- Assorted UX tweaks
  - Mostly because I don't think there's anything to 'View' like for Reports and Dashboards, so we just offer the download button
  - Also hide the download button for not-completed runs
